### PR TITLE
Improve code

### DIFF
--- a/include/trackcpp/tracking.h
+++ b/include/trackcpp/tracking.h
@@ -24,13 +24,31 @@
 #include "linalg.h"
 #include <vector>
 #include <limits>
+#include <utility>
 #include <cmath>
 
-Status::type track_findm66(const Accelerator& accelerator, const Pos<double>& fixed_point, std::vector<Matrix>& tm, Matrix& m66, Pos<double>& v0);
-Status::type track_findorbit4(const Accelerator& accelerator, std::vector<Pos<double> >& closed_orbit, const Pos<double>& fixed_point_guess = Pos<double>(0));
-Status::type track_findorbit6(const Accelerator& accelerator, std::vector<Pos<double> >& closed_orbit, const Pos<double>& fixed_point_guess = Pos<double>(0));
-Pos<double>  linalg_solve4_posvec(const std::vector<Pos<double> >& M, const Pos<double>& b);
-Pos<double>  linalg_solve6_posvec(const std::vector<Pos<double> >& M, const Pos<double>& b);
+Status::type track_findm66(
+	const Accelerator& accelerator, const Pos<double>& fixed_point,
+	std::vector<Matrix>& tm, Matrix& m66, Pos<double>& v0);
+
+Status::type track_findm66(
+	const Accelerator& accelerator, const Pos<double>& fixed_point,
+	std::vector<Matrix>& tm, Matrix& m66, Pos<double>& v0,
+	std::vector<unsigned int >& indices);
+
+Status::type track_findorbit4(
+	const Accelerator& accelerator, std::vector<Pos<double> >& closed_orbit,
+	const Pos<double>& fixed_point_guess = Pos<double>(0));
+
+Status::type track_findorbit6(
+	const Accelerator& accelerator, std::vector<Pos<double> >& closed_orbit,
+	const Pos<double>& fixed_point_guess = Pos<double>(0));
+
+Pos<double>  linalg_solve4_posvec(
+	const std::vector<Pos<double> >& M, const Pos<double>& b);
+
+Pos<double>  linalg_solve6_posvec(
+	const std::vector<Pos<double> >& M, const Pos<double>& b);
 
 
 template <typename T>
@@ -238,6 +256,44 @@ Status::type track_linepass (
 	}
 	return status;
 }
+
+// template <typename T>
+// Status::type track_linepass (
+// 		const Accelerator& accelerator,
+// 		std::vector<Pos<T> > &orig_pos,
+// 		std::vector<Pos<T> > &pos,
+// 		unsigned int element_offset,
+// 		std::vector<unsigned int >& lost_plane,
+// 		std::vector<unsigned int >& lost_element,
+// 		std::vector<unsigned int >& indices) {
+
+// 	Status::type status  = Status::success;
+// 	Status::type status2  = Status::success;
+// 	std::vector<Pos<T> > final_pos;
+// 	Plane::type lp;
+
+// 	int nr_trh = pos.size()
+
+// 	pos.reserve(indices.size() * orig_pos.size());
+//     lost_plane.reserve(orig_pos.size());
+// 	lost_element.reserve(orig_pos.size());
+
+// 	for(unsigned int i=0; i<orig_pos.size(); ++i) {
+// 		unsigned int le = element_offset;
+
+// 		status2 = track_linepass (
+// 			accelerator, orig_pos[i], final_pos, le, lp, indices);
+
+// 		if (status2 != Status::success) status = status2;
+
+// 		lost_plane.push_back(lp);
+// 		lost_element.push_back(le);
+// 		for (auto&& p: final_pos) pos.push_back(p);
+// 		final_pos.clear();
+// 	}
+// 	return status;
+// }
+
 
 
 // ringpass

--- a/include/trackcpp/tracking.h
+++ b/include/trackcpp/tracking.h
@@ -257,44 +257,6 @@ Status::type track_linepass (
 	return status;
 }
 
-// template <typename T>
-// Status::type track_linepass (
-// 		const Accelerator& accelerator,
-// 		std::vector<Pos<T> > &orig_pos,
-// 		std::vector<Pos<T> > &pos,
-// 		unsigned int element_offset,
-// 		std::vector<unsigned int >& lost_plane,
-// 		std::vector<unsigned int >& lost_element,
-// 		std::vector<unsigned int >& indices) {
-
-// 	Status::type status  = Status::success;
-// 	Status::type status2  = Status::success;
-// 	std::vector<Pos<T> > final_pos;
-// 	Plane::type lp;
-
-// 	int nr_trh = pos.size()
-
-// 	pos.reserve(indices.size() * orig_pos.size());
-//     lost_plane.reserve(orig_pos.size());
-// 	lost_element.reserve(orig_pos.size());
-
-// 	for(unsigned int i=0; i<orig_pos.size(); ++i) {
-// 		unsigned int le = element_offset;
-
-// 		status2 = track_linepass (
-// 			accelerator, orig_pos[i], final_pos, le, lp, indices);
-
-// 		if (status2 != Status::success) status = status2;
-
-// 		lost_plane.push_back(lp);
-// 		lost_element.push_back(le);
-// 		for (auto&& p: final_pos) pos.push_back(p);
-// 		final_pos.clear();
-// 	}
-// 	return status;
-// }
-
-
 
 // ringpass
 // --------

--- a/python_package/interface.cpp
+++ b/python_package/interface.cpp
@@ -166,6 +166,32 @@ Status::type write_flat_file_wrapper(String& fname, const Accelerator& accelerat
 }
 
 
+Status::type track_findm66_wrapper(
+    const Accelerator& accelerator,
+    const Pos<double>& fixed_point,
+    double *cumul_tm, int n1_tm, int n2_tm, int n3_tm,
+    double *m66, int n1_m66, int n2_m66,
+    Pos<double>& v0,
+    std::vector<unsigned int >& indices) {
+
+    std::vector<Matrix> vec_tm;
+    Matrix vec_m66;
+
+    Status::type status = track_findm66(
+        accelerator, fixed_point, vec_tm, vec_m66, v0, indices);
+
+    for (unsigned int i=0; i<vec_tm.size(); ++i){
+        Matrix& m = vec_tm[i];
+        for (unsigned int j=0; j<n2_tm; ++j)
+            for (unsigned int k=0; k<n3_tm; ++k)
+                cumul_tm[(i*n2_tm + j)*n3_tm + k] = m[j][k];
+        }
+    for (unsigned int i=0; i<n1_m66; ++i)
+        for (unsigned int j=0; j<n2_m66; ++j)
+            m66[i*n2_m66 + j] = vec_m66[i][j];
+}
+
+
 void naff_general_wrapper(
     double *re_in, int n1_re_in, int n2_re_in,
     double *im_in, int n1_im_in, int n2_im_in,

--- a/python_package/interface.cpp
+++ b/python_package/interface.cpp
@@ -164,3 +164,42 @@ Status::type read_flat_file_wrapper(String& fname, Accelerator& accelerator, boo
 Status::type write_flat_file_wrapper(String& fname, const Accelerator& accelerator, bool file_flag) {
   return write_flat_file(fname.data, accelerator, file_flag);
 }
+
+
+void naff_general_wrapper(
+    double *re_in, int n1_re_in, int n2_re_in,
+    double *im_in, int n1_im_in, int n2_im_in,
+    bool is_real, int nr_ff, int win,
+    double *ff_out, int n1_ff_out, int n2_ff_out,
+    double *re_out, int n1_re_out, int n2_re_out,
+    double *im_out, int n1_im_out, int n2_im_out){
+
+    std::vector<double> vec_re_in;
+    std::vector<double> vec_im_in;
+    std::vector<double> vec_ff_out;
+    std::vector<double> vec_re_out;
+    std::vector<double> vec_im_out;
+
+    vec_re_in.resize(n2_re_in);
+    vec_im_in.resize(n2_re_in);
+    vec_ff_out.resize(n2_ff_out, 0.0);
+    vec_re_out.resize(n2_ff_out, 0.0);
+    vec_im_out.resize(n2_ff_out, 0.0);
+    for (unsigned int i=0; i<n1_re_in; ++i){
+        for (unsigned int j=0; j<n2_re_in; ++j){
+            vec_re_in[j] = re_in[i*n2_re_in + j];
+            vec_im_in[j] = im_in[i*n2_re_in + j];
+        }
+
+        naff_general(
+            vec_re_in, vec_im_in,
+            is_real, nr_ff, win,
+            vec_ff_out, vec_re_out, vec_im_out);
+
+        for (unsigned int j=0; j<n2_ff_out; ++j){
+            ff_out[i*n2_ff_out + j] = vec_ff_out[j];
+            re_out[i*n2_ff_out + j] = vec_re_out[j];
+            im_out[i*n2_ff_out + j] = vec_im_out[j];
+        }
+    }
+}

--- a/python_package/interface.h
+++ b/python_package/interface.h
@@ -84,6 +84,14 @@ Status::type write_flat_file_wrapper(String& fname, const Accelerator& accelerat
 Status::type read_flat_file_wrapper(String& fname, Accelerator& accelerator, bool file_flag = true);
 
 
+Status::type track_findm66_wrapper(
+    const Accelerator& accelerator,
+    const Pos<double>& fixed_point,
+    double *cumul_tm, int n1_tm, int n2_tm, int n3_tm,
+    double *m66, int n1_m66, int n2_m66,
+    Pos<double>& v0, std::vector<unsigned int >& indices);
+
+
 void naff_general_wrapper(
     double *re_in, int n1_re_in, int n2_re_in,
     double *im_in, int n1_im_in, int n2_im_in,

--- a/python_package/interface.h
+++ b/python_package/interface.h
@@ -24,6 +24,7 @@
 #include <trackcpp/auxiliary.h>
 #include <trackcpp/tracking.h>
 #include <trackcpp/pos.h>
+#include <trackcpp/naff.h>
 
 struct LinePassArgs {
     unsigned int element_offset;
@@ -81,5 +82,14 @@ Element rbend_wrapper(const std::string& fam_name_, const double& length_,
                       const double& K_, const double& S_);
 Status::type write_flat_file_wrapper(String& fname, const Accelerator& accelerator, bool file_flag = true);
 Status::type read_flat_file_wrapper(String& fname, Accelerator& accelerator, bool file_flag = true);
+
+
+void naff_general_wrapper(
+    double *re_in, int n1_re_in, int n2_re_in,
+    double *im_in, int n1_im_in, int n2_im_in,
+    bool is_real, int nr_ff, int win,
+    double *ff_out, int n1_ff_out, int n2_ff_out,
+    double *re_out, int n1_re_out, int n2_re_out,
+    double *im_out, int n1_im_out, int n2_im_out);
 
 #endif // INTERFACE_H

--- a/python_package/trackcpp.i
+++ b/python_package/trackcpp.i
@@ -73,6 +73,12 @@ double get_double_max() {
 %apply (double* INPLACE_ARRAY2, int DIM1, int DIM2 ) {
     (double* pos, int n1, int n2)}
 
+//For find_m66
+%apply (double* INPLACE_ARRAY3, int DIM1, int DIM2, int DIM3 ) {
+    (double *cumul_tm, int n1_tm, int n2_tm, int n3_tm)}
+%apply (double* INPLACE_ARRAY2, int DIM1, int DIM2 ) {
+    (double *m66, int n1_m66, int n2_m66)}
+
 // For naff_general
 %apply (double* IN_ARRAY2, int DIM1, int DIM2 ){
     (double* re_in, int n1_re_in, int n2_re_in)}

--- a/python_package/trackcpp.i
+++ b/python_package/trackcpp.i
@@ -67,10 +67,24 @@ double get_double_max() {
     import_array();
 %}
 
+// For ringpass and linepass
 %apply (double* IN_ARRAY2, int DIM1, int DIM2 ){
     (double* orig_pos, int ni1, int ni2)}
 %apply (double* INPLACE_ARRAY2, int DIM1, int DIM2 ) {
     (double* pos, int n1, int n2)}
+
+// For naff_general
+%apply (double* IN_ARRAY2, int DIM1, int DIM2 ){
+    (double* re_in, int n1_re_in, int n2_re_in)}
+%apply (double* IN_ARRAY2, int DIM1, int DIM2 ){
+    (double* im_in, int n1_im_in, int n2_im_in)}
+%apply (double* INPLACE_ARRAY2, int DIM1, int DIM2 ) {
+    (double *ff_out, int n1_ff_out, int n2_ff_out)}
+%apply (double* INPLACE_ARRAY2, int DIM1, int DIM2 ) {
+    (double *re_out, int n1_re_out, int n2_re_out)}
+%apply (double* INPLACE_ARRAY2, int DIM1, int DIM2 ) {
+    (double *im_out, int n1_im_out, int n2_im_out)}
+
 
 %include "../include/trackcpp/elements.h"
 %include "../include/trackcpp/kicktable.h"

--- a/src/tracking.cpp
+++ b/src/tracking.cpp
@@ -40,7 +40,8 @@ Status::type track_findm66 (const Accelerator& accelerator,
                             const Pos<double>& fixed_point,
                             std::vector<Matrix>& tm,
                             Matrix& m66,
-                            Pos<double>& v0) {
+                            Pos<double>& v0,
+                            std::vector<unsigned int >& indices) {
 
   Status::type status  = Status::success;
   const std::vector<Element>& lattice = accelerator.lattice;
@@ -50,35 +51,55 @@ Status::type track_findm66 (const Accelerator& accelerator,
   // case no closed_orbit has been defined
   if (std::isnan(fp.rx)) fp = Pos<double>(0,0,0,0,0,0);
 
+  int nr_elements  = lattice.size();
+	std::vector<bool> indcs;
+	indcs.reserve(nr_elements+1);
+	for (unsigned int i=0; i<=nr_elements; ++i) indcs[i] = false;
+	for (auto&& i: indices) if (i<=nr_elements) indcs[i] = true;
 
   Pos<Tpsa<6,1> > map;
   map.rx = Tpsa<6,1>(fp.rx, 0); map.px = Tpsa<6,1>(fp.px, 1);
   map.ry = Tpsa<6,1>(fp.ry, 2); map.py = Tpsa<6,1>(fp.py, 3);
   map.de = Tpsa<6,1>(fp.de, 4); map.dl = Tpsa<6,1>(fp.dl, 5);
 
-  tm.clear(); tm.resize(lattice.size()+1, Matrix(6));
+  tm.clear(); tm.reserve(indices.size());
   for(unsigned int i=0; i<lattice.size(); ++i) {
-    Matrix& m = tm[i];
-    m[0][0] = map.rx.c[1]; m[0][1] = map.rx.c[2]; m[0][2] = map.rx.c[3]; m[0][3] = map.rx.c[4]; m[0][4] = map.rx.c[5]; m[0][5] = map.rx.c[6];
-    m[1][0] = map.px.c[1]; m[1][1] = map.px.c[2]; m[1][2] = map.px.c[3]; m[1][3] = map.px.c[4]; m[1][4] = map.px.c[5]; m[1][5] = map.px.c[6];
-    m[2][0] = map.ry.c[1]; m[2][1] = map.ry.c[2]; m[2][2] = map.ry.c[3]; m[2][3] = map.ry.c[4]; m[2][4] = map.ry.c[5]; m[2][5] = map.ry.c[6];
-    m[3][0] = map.py.c[1]; m[3][1] = map.py.c[2]; m[3][2] = map.py.c[3]; m[3][3] = map.py.c[4]; m[3][4] = map.py.c[5]; m[3][5] = map.py.c[6];
-    m[4][0] = map.de.c[1]; m[4][1] = map.de.c[2]; m[4][2] = map.de.c[3]; m[4][3] = map.de.c[4]; m[4][4] = map.de.c[5]; m[4][5] = map.de.c[6];
-    m[5][0] = map.dl.c[1]; m[5][1] = map.dl.c[2]; m[5][2] = map.dl.c[3]; m[5][3] = map.dl.c[4]; m[5][4] = map.dl.c[5]; m[5][5] = map.dl.c[6];
+    if (indcs[i]){
+      Matrix m (6);
+      m[0][0] = map.rx.c[1]; m[0][1] = map.rx.c[2]; m[0][2] = map.rx.c[3];
+      m[0][3] = map.rx.c[4]; m[0][4] = map.rx.c[5]; m[0][5] = map.rx.c[6];
+      m[1][0] = map.px.c[1]; m[1][1] = map.px.c[2]; m[1][2] = map.px.c[3];
+      m[1][3] = map.px.c[4]; m[1][4] = map.px.c[5]; m[1][5] = map.px.c[6];
+      m[2][0] = map.ry.c[1]; m[2][1] = map.ry.c[2]; m[2][2] = map.ry.c[3];
+      m[2][3] = map.ry.c[4]; m[2][4] = map.ry.c[5]; m[2][5] = map.ry.c[6];
+      m[3][0] = map.py.c[1]; m[3][1] = map.py.c[2]; m[3][2] = map.py.c[3];
+      m[3][3] = map.py.c[4]; m[3][4] = map.py.c[5]; m[3][5] = map.py.c[6];
+      m[4][0] = map.de.c[1]; m[4][1] = map.de.c[2]; m[4][2] = map.de.c[3];
+      m[4][3] = map.de.c[4]; m[4][4] = map.de.c[5]; m[4][5] = map.de.c[6];
+      m[5][0] = map.dl.c[1]; m[5][1] = map.dl.c[2]; m[5][2] = map.dl.c[3];
+      m[5][3] = map.dl.c[4]; m[5][4] = map.dl.c[5]; m[5][5] = map.dl.c[6];
+    tm.push_back(std::move(m));
+    }
     // track through element
     if ((status = track_elementpass (lattice[i], map, accelerator)) != Status::success) return status;
   }
 
   m66 = Matrix(6);
   Matrix& m = m66;
-  m[0][0] = map.rx.c[1]; m[0][1] = map.rx.c[2]; m[0][2] = map.rx.c[3]; m[0][3] = map.rx.c[4]; m[0][4] = map.rx.c[5]; m[0][5] = map.rx.c[6];
-  m[1][0] = map.px.c[1]; m[1][1] = map.px.c[2]; m[1][2] = map.px.c[3]; m[1][3] = map.px.c[4]; m[1][4] = map.px.c[5]; m[1][5] = map.px.c[6];
-  m[2][0] = map.ry.c[1]; m[2][1] = map.ry.c[2]; m[2][2] = map.ry.c[3]; m[2][3] = map.ry.c[4]; m[2][4] = map.ry.c[5]; m[2][5] = map.ry.c[6];
-  m[3][0] = map.py.c[1]; m[3][1] = map.py.c[2]; m[3][2] = map.py.c[3]; m[3][3] = map.py.c[4]; m[3][4] = map.py.c[5]; m[3][5] = map.py.c[6];
-  m[4][0] = map.de.c[1]; m[4][1] = map.de.c[2]; m[4][2] = map.de.c[3]; m[4][3] = map.de.c[4]; m[4][4] = map.de.c[5]; m[4][5] = map.de.c[6];
-  m[5][0] = map.dl.c[1]; m[5][1] = map.dl.c[2]; m[5][2] = map.dl.c[3]; m[5][3] = map.dl.c[4]; m[5][4] = map.dl.c[5]; m[5][5] = map.dl.c[6];
+  m[0][0] = map.rx.c[1]; m[0][1] = map.rx.c[2]; m[0][2] = map.rx.c[3];
+  m[0][3] = map.rx.c[4]; m[0][4] = map.rx.c[5]; m[0][5] = map.rx.c[6];
+  m[1][0] = map.px.c[1]; m[1][1] = map.px.c[2]; m[1][2] = map.px.c[3];
+  m[1][3] = map.px.c[4]; m[1][4] = map.px.c[5]; m[1][5] = map.px.c[6];
+  m[2][0] = map.ry.c[1]; m[2][1] = map.ry.c[2]; m[2][2] = map.ry.c[3];
+  m[2][3] = map.ry.c[4]; m[2][4] = map.ry.c[5]; m[2][5] = map.ry.c[6];
+  m[3][0] = map.py.c[1]; m[3][1] = map.py.c[2]; m[3][2] = map.py.c[3];
+  m[3][3] = map.py.c[4]; m[3][4] = map.py.c[5]; m[3][5] = map.py.c[6];
+  m[4][0] = map.de.c[1]; m[4][1] = map.de.c[2]; m[4][2] = map.de.c[3];
+  m[4][3] = map.de.c[4]; m[4][4] = map.de.c[5]; m[4][5] = map.de.c[6];
+  m[5][0] = map.dl.c[1]; m[5][1] = map.dl.c[2]; m[5][2] = map.dl.c[3];
+  m[5][3] = map.dl.c[4]; m[5][4] = map.dl.c[5]; m[5][5] = map.dl.c[6];
 
-  tm[lattice.size()] = m66;
+  if (indcs[lattice.size()]) tm.push_back(m66);
 
   // constant term of the final map
   v0.rx = map.rx.c[0]; v0.px = map.px.c[0]; v0.ry = map.ry.c[0]; v0.py = map.py.c[0]; v0.de = map.de.c[0]; v0.dl = map.dl.c[0];
@@ -86,6 +107,23 @@ Status::type track_findm66 (const Accelerator& accelerator,
   return status;
 
 }
+
+
+Status::type track_findm66 (const Accelerator& accelerator,
+                            const Pos<double>& fixed_point,
+                            std::vector<Matrix>& tm,
+                            Matrix& m66,
+                            Pos<double>& v0) {
+
+  std::vector<unsigned int> indices;
+  unsigned int nr_elements = accelerator.lattice.size();
+
+  indices.reserve(nr_elements + 1);
+	for (unsigned int i=0; i<=nr_elements; ++i) indices.push_back(i);
+
+	return track_findm66 (accelerator, fixed_point, tm, m66, v0, indices);
+}
+
 
 Status::type track_findorbit6(
     const Accelerator& accelerator,


### PR DESCRIPTION
- NAFF.ENH: Generalize naff method to handle several trajectories at once.
- TRACK.ENH: improve findm66:
   - add wrapper to convert objects to `numpy` to improve speed in `pyaccel`;
   - add indices to return acummulated matrices.

