### PR TITLE
Fix inconsistency of new Kickmap API and kicktable list optimization

### DIFF
--- a/include/trackcpp/accelerator.h
+++ b/include/trackcpp/accelerator.h
@@ -26,7 +26,6 @@ class Accelerator {
 public:
   // energy < electron_rest_energy -> energy = electron_rest_energy:
   Accelerator(const double& energy=-1);
-
   double                  energy;              // [eV]
   bool                    cavity_on;
   bool                    radiation_on;
@@ -40,7 +39,6 @@ public:
   bool isequal(const Accelerator& a) const { return *this == a; } // necessary for python_package
   double get_length() const;
   friend std::ostream& operator<< (std::ostream &out, const Accelerator& a);
-
 };
 
 #endif

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -34,9 +34,9 @@ public:
   static const int pm_cavity_pass                    = 5;
   static const int pm_thinquad_pass                  = 6;
   static const int pm_thinsext_pass                  = 7;
-  static const int pm_kicktable_pass                 = 8;
+  static const int pm_kickmap_pass                   = 8;
   static const int pm_matrix_pass                    = 9;
-  static const int pm_nr_pms                         = 10;
+  static const int pm_nr_pms                         = 10;  // counter for number of passmethods
   PassMethodsClass() {
     passmethods.push_back("identity_pass");
     passmethods.push_back("drift_pass");
@@ -66,7 +66,7 @@ struct PassMethod {
         pm_cavity_pass                    = 5,
         pm_thinquad_pass                  = 6,
         pm_thinsext_pass                  = 7,
-        pm_kicktable_pass                 = 8,
+        pm_kickmap_pass                   = 8,
         pm_matrix_pass                    = 9,
         pm_nr_pms                         = 10,
     };

--- a/include/trackcpp/elements.h
+++ b/include/trackcpp/elements.h
@@ -59,6 +59,7 @@ public:
   double        frequency   = 0;  // [Hz]
   double        voltage     = 0;  // [V]
   double        phase_lag   = 0;  // [rad]
+  double        rescale_kicks  = 1.0;  // for kickmaps
 
   std::vector<double> polynom_a = default_polynom;
   std::vector<double> polynom_b = default_polynom;
@@ -115,6 +116,6 @@ void initialize_rbend(Element& element, const double& angle, const double& angle
 void initialize_quadrupole(Element& element, const double& K, const int& nr_steps);
 void initialize_sextupole(Element& element, const double& S, const int& nr_steps);
 void initialize_rfcavity(Element& element, const double& frequency, const double& voltage, const double& phase_lag);
-void initialize_kickmap(Element& element, const int& nr_steps, const Kicktable& kicktable);
+void initialize_kickmap(Element& element, const Kicktable& kicktable, const int& nr_steps, const double &rescale_kicks);
 
 #endif

--- a/include/trackcpp/kicktable.h
+++ b/include/trackcpp/kicktable.h
@@ -39,10 +39,9 @@ public:
   unsigned int        x_nrpts, y_nrpts;
   double              x_min, x_max;
   double              y_min, y_max;
-  double              rescale_length, rescale_kicks;
   std::vector<double> x_kick,  y_kick;
 
-  Kicktable(const std::string& filename_ = "", const double& rescale_length = 1.0, const double& rescale_kicks = 1.0);
+  Kicktable(const std::string& filename_ = "");
   Kicktable(const Kicktable &) = default;
 
   Status::type load_from_file(const std::string& filename_);

--- a/include/trackcpp/kicktable.h
+++ b/include/trackcpp/kicktable.h
@@ -22,12 +22,6 @@
 #include <vector>
 
 
-class Kick {
-public:
-    double hkick, vkick;
-    Status::type status;
-};
-
 class Kicktable {
 
   // Kicktable: assumes x_kick and y_kick tables sampled on the same regular (x,y)-point grid.
@@ -51,8 +45,6 @@ public:
   double       get_y(unsigned int iy) const { return y_min + iy * (y_max - y_min) / (y_nrpts - 1.0); }
   template <typename T> unsigned int get_ix(const T& x) const { return (int) ((x - x_min) / ((x_max - x_min) / (x_nrpts - 1))); }
   template <typename T> unsigned int get_iy(const T& y) const { return (int) ((y - y_min) / ((y_max - y_min) / (y_nrpts - 1))); }
-
-  Kick interpolate_kicks(const double& rx, const double& ry) const;
 
   bool operator==(const Kicktable& o) const;
   bool operator!=(const Kicktable& o) const { return !(*this == o); }

--- a/include/trackcpp/passmethods.h
+++ b/include/trackcpp/passmethods.h
@@ -60,7 +60,7 @@ template <typename T> Status::type pm_corrector_pass             (Pos<T> &pos, c
 template <typename T> Status::type pm_cavity_pass                (Pos<T> &pos, const Element &elem, const Accelerator& accelerator);
 template <typename T> Status::type pm_thinquad_pass              (Pos<T> &pos, const Element &elem, const Accelerator& accelerator);
 template <typename T> Status::type pm_thinsext_pass              (Pos<T> &pos, const Element &elem, const Accelerator& accelerator);
-template <typename T> Status::type pm_kicktable_pass             (Pos<T> &pos, const Element &elem, const Accelerator& accelerator);
+template <typename T> Status::type pm_kickmap_pass               (Pos<T> &pos, const Element &elem, const Accelerator& accelerator);
 template <typename T> Status::type pm_matrix_pass                (Pos<T> &pos, const Element &elem, const Accelerator& accelerator);
 
 #include "passmethods.hpp"

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -91,7 +91,7 @@ T b2_perp(const T& bx, const T& by, const T& rx, const T& px,
 
 template <typename T>
 Status::type kicktablethinkick(Pos<T>& pos, const Kicktable* kicktable,
-                               const double& brho, const int nr_steps, const float rescale_kicks) {
+                               const double& brho, const int nr_steps, const double& rescale_kicks) {
 
   T hkick, vkick;
   Status::type status = kicktable_getkicks(kicktable, pos.rx, pos.ry, hkick, vkick);

--- a/include/trackcpp/tracking.h
+++ b/include/trackcpp/tracking.h
@@ -84,8 +84,8 @@ Status::type track_elementpass (
 	case PassMethod::pm_thinsext_pass:
 		if ((status = pm_thinsext_pass<T>(orig_pos, el, accelerator)) != Status::success) return status;
 		break;
-	case PassMethod::pm_kicktable_pass:
-		if ((status = pm_kicktable_pass<T>(orig_pos, el, accelerator)) != Status::success) return status;
+	case PassMethod::pm_kickmap_pass:
+		if ((status = pm_kickmap_pass<T>(orig_pos, el, accelerator)) != Status::success) return status;
 		break;
 	case PassMethod::pm_matrix_pass:
 		if ((status = pm_matrix_pass<T>(orig_pos, el, accelerator)) != Status::success) return status;

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -19,7 +19,6 @@
 #include <trackcpp/kicktable.h>
 #include <cfloat>
 
-std::vector<std::string> kicktable_fname;
 std::vector<Kicktable> kicktable_list;
 
 
@@ -129,17 +128,16 @@ Element Element::kickmap (const std::string& fam_name_, const std::string& kickt
 
   // add new kicktable to global list, if necessary.
   int i;
-  for(i=0; i<kicktable_fname.size(); ++i)
-    if (kicktable_fname[i] == kicktable_fname_) break;
-  if (i == kicktable_fname.size()) {
-    kicktable_fname.push_back(kicktable_fname_);
-    kicktable_list.push_back(Kicktable(kicktable_fname_, rescale_length_, rescale_kicks_));
-    i = kicktable_fname.size() - 1;
+  for(i=0; i<kicktable_list.size(); ++i)
+    if (kicktable_list[i].filename == kicktable_fname_) break;
+  if (i == kicktable_list.size()) {
+    kicktable_list.push_back(Kicktable(kicktable_fname_));
+    i = kicktable_list.size() - 1;
   }
 
   const Kicktable& kicktable = kicktable_list[i];
-  Element e = Element(fam_name_, kicktable.length);
-    initialize_kickmap(e, nr_steps_, kicktable);
+  Element e = Element(fam_name_, rescale_length_ * kicktable.length);
+    initialize_kickmap(e, kicktable, nr_steps_, rescale_kicks_);
   return e;
 }
 
@@ -284,9 +282,9 @@ void initialize_rfcavity(Element &element, const double &frequency, const double
     element.voltage = voltage;
     element.phase_lag = phase_lag;
 }
-
-void initialize_kickmap(Element &element, const int &nr_steps, const Kicktable& kicktable) {
-    element.pass_method = PassMethod::pm_kicktable_pass;
+void initialize_kickmap(Element& element, const Kicktable& kicktable, const int& nr_steps, const double &rescale_kicks) {
+    element.pass_method = PassMethod::pm_kickmap_pass;
     element.nr_steps = nr_steps;
     element.kicktable = &kicktable;
+    element.rescale_kicks = rescale_kicks;
 }

--- a/src/flat_file.cpp
+++ b/src/flat_file.cpp
@@ -380,7 +380,7 @@ static Status::type read_flat_file_tracy(const std::string& filename, Accelerato
       }; break;
       case FlatFileType::kicktable:
       {
-        e.pass_method = PassMethod::pm_kicktable_pass;
+        e.pass_method = PassMethod::pm_kickmap_pass;
         double tmpdbl; std::string filename;
         fp >> tmpdbl >> tmpdbl >> filename;
         Status::type status = add_kicktable(filename, accelerator.kicktables, e.kicktable);

--- a/src/kicktable.cpp
+++ b/src/kicktable.cpp
@@ -122,12 +122,6 @@ void del_kicktables(std::vector<Kicktable*>& kicktable_list) {
   }
 }
 
-Kick Kicktable::interpolate_kicks(const double& rx, const double& ry) const {
-    Kick kick;
-    kick.status = kicktable_getkicks(this, rx, ry, kick.hkick, kick.vkick);
-    return kick;
-}
-
 bool Kicktable::operator==(const Kicktable& o) const {
   if (this == &o) return true;
   if (this->length != o.length) return false;

--- a/src/kicktable.cpp
+++ b/src/kicktable.cpp
@@ -20,10 +20,9 @@
 #include <fstream>
 #include <cmath>
 
-Kicktable::Kicktable(const std::string& filename_, const double& rescale_length_, const double& rescale_kicks_) :
+Kicktable::Kicktable(const std::string& filename_) :
   filename(""),
   x_nrpts(0), y_nrpts(0),
-  rescale_length(rescale_length_), rescale_kicks(rescale_kicks_),
   x_min(nan("")), x_max(nan("")),
   y_min(nan("")), y_max(nan("")) {
 
@@ -49,7 +48,6 @@ Status::type Kicktable::load_from_file(const std::string& filename_) {
   getline(fp, str);   // author line
   getline(fp, str);   // label 'ID length[m]'
   fp >> this->length; // length of element
-  this->length *= this->rescale_length;
   getline(fp, str);   // advances to new line
   getline(fp, str);   // label 'number of horizontal points'
   fp >> this->x_nrpts;      // number of horizontal points
@@ -75,10 +73,8 @@ Status::type Kicktable::load_from_file(const std::string& filename_) {
     double posy; fp >> posy;
     if (std::isnan(y_min) or posy < y_min) y_min = posy;
     if (std::isnan(y_max) or posy > y_max) y_max = posy;
-    for(unsigned int i=0; i<x_nrpts; ++i) {
-      fp >> kick;
-      x_kick[this->get_idx(i,j)] = kick * this->rescale_kicks;
-    }
+    for(unsigned int i=0; i<x_nrpts; ++i)
+      fp >> x_kick[this->get_idx(i,j)];
   }
   getline(fp, str);   // advances to new line
 
@@ -88,10 +84,8 @@ Status::type Kicktable::load_from_file(const std::string& filename_) {
   for(unsigned int i=0; i<this->x_nrpts; ++i) { double posx; fp >> posx; }
   for(int j=y_nrpts-1; j>=0; --j) {
     double posy; fp >> posy;
-    for(unsigned int i=0; i<x_nrpts; ++i) {
-      fp >> kick;
-      y_kick[this->get_idx(i,j)] = kick * this->rescale_kicks;
-    }
+    for(unsigned int i=0; i<x_nrpts; ++i)
+      fp >> y_kick[this->get_idx(i,j)];
   }
 
   return Status::success;


### PR DESCRIPTION
- Change implementation of kickmap scaling factors. As it was, there was an inconsistency with optimization of memory use for kickmaps that relied on a global list of kicktables.
- Bug fix: rescale_length was not being applied!