### PR TITLE
Include quantum excitation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ LIBSOURCES_CPP  =	lattice.cpp \
 					multithreads.cpp \
 					accelerator.cpp \
 					naff.cpp \
-					linalg.cpp
+					linalg.cpp \
+					auxiliary.cpp
 BINSOURCES_CPP =	exec.cpp \
 					tests.cpp \
 					commands.cpp \

--- a/include/trackcpp/accelerator.h
+++ b/include/trackcpp/accelerator.h
@@ -29,6 +29,7 @@ public:
   double                  energy;              // [eV]
   bool                    cavity_on;
   bool                    radiation_on;
+  bool                    quantdiff_on;
   bool                    vchamber_on;
   int                     harmonic_number;
   std::vector<Element>    lattice;

--- a/include/trackcpp/accelerator.h
+++ b/include/trackcpp/accelerator.h
@@ -28,8 +28,7 @@ public:
   Accelerator(const double& energy=-1);
   double                  energy;              // [eV]
   bool                    cavity_on;
-  bool                    radiation_on;
-  bool                    quantdiff_on;
+  int                     radiation_on;
   bool                    vchamber_on;
   int                     harmonic_number;
   std::vector<Element>    lattice;

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -101,6 +101,18 @@ const std::vector<std::string> rad_dict = {
     "full"
 };
 
+struct Distributions {
+    enum type {
+        normal =  0,
+        uniform  =  1,
+    };
+};
+
+const std::vector<std::string> distributions_dict = {
+    "normal",
+    "uniform",
+};
+
 struct Status {
     enum type {
         success = 0,
@@ -183,6 +195,7 @@ int sgn(T val) {
 
 
 void set_random_seed(unsigned rnd_seed);
+void set_random_distribution(unsigned value);
 double gen_random_number();
 
 

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -87,6 +87,20 @@ const std::vector<std::string> pm_dict = {
     "matrix_pass"
 };
 
+struct RadiationState {
+    enum type {
+        off                    = 0,
+        damping                = 1,
+        full                   = 2,
+    };
+};
+
+const std::vector<std::string> rad_dict = {
+    "off",
+    "damping",
+    "full"
+};
+
 struct Status {
     enum type {
         success = 0,

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -168,6 +168,7 @@ int sgn(T val) {
 }
 
 
+void set_random_seed(unsigned rnd_seed);
 double gen_random_number();
 
 

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -167,13 +167,43 @@ int sgn(T val) {
     if (val >= 0) return 1; else return -1;
 }
 
-template <typename T>
-T random_normal(T mean, T stddev) {
-    std::random_device             rand_dev;
-    std::mt19937                   generator(rand_dev());
-    std::normal_distribution<T>    distr(mean, stddev);
-    return distr(generator);
-}
+class RandomGen{
+    private:
+    int seed;
+    std::random_device rand_dev;
+    std::mt19937  generator;
+    std::normal_distribution<double>  distr;
+    
+    public:
+    RandomGen(const int seedIn){
+        seed = seedIn;
+        std::random_device rand_dev;
+        std::mt19937  generator(seed);
+        std::normal_distribution<double>  distr(0., 0.1);
+    }
+    void setSeed(const int seedIn){
+        seed = seedIn;
+        generator.seed(seedIn);
+    }
+    int getSeed(){
+        return seed;
+    }
+    void setRandomSeed(){
+        seed = rand_dev();
+        generator.seed(seed);
+    }
+    double genNormalNumber(){
+        return distr(generator);
+    };
+};
+
+// double random_normal(int seed=0) {
+//     // std::random_device             rand_dev;
+//     // std::mt19937                   generator(rand_dev());
+//     std::default_random_engine             generator();
+//     std::normal_distribution<double>       distr(0., 1.);
+//     return distr(generator);
+// }
 
 #if __GNUC__ < 6
     bool isfinite(const double& v);

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -22,7 +22,7 @@
 #include <ostream>
 #include <iostream>
 #include <cmath>
-
+#include <random>
 
 class PassMethodsClass {
 public:
@@ -167,6 +167,13 @@ int sgn(T val) {
     if (val >= 0) return 1; else return -1;
 }
 
+template <typename T>
+T random_normal(T mean, T stddev) {
+    std::random_device             rand_dev;
+    std::mt19937                   generator(rand_dev());
+    std::normal_distribution<T>    distr(mean, stddev);
+    return distr(generator);
+}
 
 #if __GNUC__ < 6
     bool isfinite(const double& v);

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -167,43 +167,9 @@ int sgn(T val) {
     if (val >= 0) return 1; else return -1;
 }
 
-class RandomGen{
-    private:
-    int seed;
-    std::random_device rand_dev;
-    std::mt19937  generator;
-    std::normal_distribution<double>  distr;
-    
-    public:
-    RandomGen(const int seedIn){
-        seed = seedIn;
-        std::random_device rand_dev;
-        std::mt19937  generator(seed);
-        std::normal_distribution<double>  distr(0., 0.1);
-    }
-    void setSeed(const int seedIn){
-        seed = seedIn;
-        generator.seed(seedIn);
-    }
-    int getSeed(){
-        return seed;
-    }
-    void setRandomSeed(){
-        seed = rand_dev();
-        generator.seed(seed);
-    }
-    double genNormalNumber(){
-        return distr(generator);
-    };
-};
 
-// double random_normal(int seed=0) {
-//     // std::random_device             rand_dev;
-//     // std::mt19937                   generator(rand_dev());
-//     std::default_random_engine             generator();
-//     std::normal_distribution<double>       distr(0., 1.);
-//     return distr(generator);
-// }
+double gen_random_number();
+
 
 #if __GNUC__ < 6
     bool isfinite(const double& v);

--- a/include/trackcpp/passmethods.h
+++ b/include/trackcpp/passmethods.h
@@ -49,6 +49,9 @@ const double KICK2 = -0.1702414383919314656e01;
   const double CU = 55/(24*std::sqrt(3));
 #endif
 
+const double CQEXT = sqrt(CU * CER * reduced_planck_constant *
+  electron_charge * light_speed) * electron_charge * electron_charge /
+  pow(electron_mass*light_speed*light_speed, 3);  // for quant. diff. kick
 
 double get_magnetic_rigidity(const double energy);
 

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -146,8 +146,7 @@ void strthinkick(Pos<T>& pos, const double& length,
 
     if (d_factor != 0) {
       // quantum excitation kick
-      T dl_ds = (1 + rx*sqrt(b2p));
-      T d = pow(sqrt(b2p), 3) * d_factor * dl_ds;
+      T d = pow(sqrt(b2p), 3) * d_factor;
       double random_number = gen_random_number();
       T qkick = sqrt(d) * random_number;
       pos.de += qkick;
@@ -188,7 +187,7 @@ void bndthinkick(Pos<T>& pos, const double& length,
     if (d_factor != 0) {
       // quantum excitation kick
       T dl_ds = (1 + rx*irho);
-      T d = d_factor * dl_ds;
+      T d = d_factor * pow(sqrt(b2p), 3) * dl_ds;
       double random_number = gen_random_number();
       T qkick = sqrt(d) * random_number;
       pos.de += qkick;
@@ -324,7 +323,7 @@ Status::type pm_bnd_mpole_symplectic4_pass(Pos<T> &pos, const Element &elem,
     const double p0_SI = p0 * electron_charge;
     const double gamma = accelerator.energy/M0C2;
     d_factor = CU * CER * reduced_planck_constant*pow(gamma, 4)/pow(electron_mass, 2)
-      * pow(abs(irho), 3)*pow(p0, 2)*p0_SI/pow(accelerator.energy, 2)*sl;
+      *pow(p0, 2)*p0_SI/pow(accelerator.energy, 2)*sl;
   }
 
   global_2_local(pos, elem);

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -141,14 +141,14 @@ void strthinkick(Pos<T>& pos, const double& length,
     T b2p = b2_perp(imag_sum, real_sum, rx, px, ry, py, 0);
     double radiation_constant =
       CGAMMA*POW3(accelerator.energy/1e9)/(TWOPI); /*[m] M.Sands(4.1)*/
-    pos.de -=
-      radiation_constant*SQR(1+pos.de)*b2p*(1+(px*px + py*py)/2)*length;
+    T delta_factor = SQR(1 + pos.de);
+    T dl_ds = (1 + (px*px + py*py)/2);
+    pos.de -= radiation_constant*delta_factor*b2p*dl_ds*length;
 
     if (d_factor != 0) {
       // quantum excitation kick
-      T d = pow(sqrt(b2p), 3) * d_factor;
-      double random_number = gen_random_number();
-      T qkick = sqrt(d) * random_number;
+      T d = delta_factor * sqrt(d_factor * pow(sqrt(b2p), 3) * dl_ds);
+      T qkick = d * gen_random_number();
       pos.de += qkick;
     }
 
@@ -181,15 +181,14 @@ void bndthinkick(Pos<T>& pos, const double& length,
     T b2p = b2_perp(imag_sum, real_sum + irho, rx, px, ry, py, irho);
     double radiation_constant =
       CGAMMA*POW3(accelerator.energy/1e9)/(TWOPI); /*[m] M.Sands(4.1)*/
-    pos.de -=
-      radiation_constant*SQR(1+pos.de)*b2p*(1+irho*rx + (px*px+py*py)/2)*length;
+    T delta_factor = SQR(1 + pos.de);
+    T dl_ds = (1 + irho*rx + (px*px+py*py)/2);
+    pos.de -= radiation_constant*delta_factor*b2p*dl_ds*length;
 
     if (d_factor != 0) {
       // quantum excitation kick
-      T dl_ds = (1 + rx*irho);
-      T d = d_factor * pow(sqrt(b2p), 3) * dl_ds;
-      double random_number = gen_random_number();
-      T qkick = sqrt(d) * random_number;
+      T d = delta_factor * sqrt(d_factor * pow(sqrt(b2p), 3) * dl_ds);
+      T qkick = d * gen_random_number();
       pos.de += qkick;
     }
 
@@ -283,7 +282,7 @@ Status::type pm_str_mpole_symplectic4_pass(Pos<T> &pos, const Element &elem,
   const std::vector<double> &polynom_b = elem.polynom_b;
   double d_factor = 0; // quantum excitation scale factor
 
-  if (accelerator.quantdiff_on){
+  if (accelerator.radiation_on && accelerator.quantdiff_on){
     const double p0 = accelerator.energy/light_speed;
     const double p0_SI = p0 * electron_charge;
     const double gamma = accelerator.energy/M0C2;
@@ -318,7 +317,7 @@ Status::type pm_bnd_mpole_symplectic4_pass(Pos<T> &pos, const Element &elem,
   const std::vector<double> &polynom_b = elem.polynom_b;
   double d_factor = 0; // quantum excitation scale factor
 
-  if (accelerator.quantdiff_on) {
+  if (accelerator.radiation_on && accelerator.quantdiff_on) {
     const double p0 = accelerator.energy/light_speed;
     const double p0_SI = p0 * electron_charge;
     const double gamma = accelerator.energy/M0C2;

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -282,7 +282,7 @@ Status::type pm_str_mpole_symplectic4_pass(Pos<T> &pos, const Element &elem,
   const std::vector<double> &polynom_b = elem.polynom_b;
   double d_factor = 0; // quantum excitation scale factor
 
-  if (accelerator.radiation_on && accelerator.quantdiff_on){
+  if (accelerator.radiation_on == RadiationState::full){
     const double p0 = accelerator.energy/light_speed;
     const double p0_SI = p0 * electron_charge;
     const double gamma = accelerator.energy/M0C2;
@@ -317,7 +317,7 @@ Status::type pm_bnd_mpole_symplectic4_pass(Pos<T> &pos, const Element &elem,
   const std::vector<double> &polynom_b = elem.polynom_b;
   double d_factor = 0; // quantum excitation scale factor
 
-  if (accelerator.radiation_on && accelerator.quantdiff_on) {
+  if (accelerator.radiation_on == RadiationState::full) {
     const double p0 = accelerator.energy/light_speed;
     const double p0_SI = p0 * electron_charge;
     const double gamma = accelerator.energy/M0C2;

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -156,7 +156,8 @@ void bndthinkick(Pos<T>& pos, const double& length,
                  const std::vector<double>& polynom_b,
                  const double& irho,
                  const Accelerator& accelerator,
-                 const bool quantum_kick_on) {
+                 const bool quantum_kick_on,
+                 const double random_number=0) {
 
   T real_sum, imag_sum;
   calcpolykick<T>(pos, polynom_a, polynom_b, real_sum, imag_sum);
@@ -175,9 +176,9 @@ void bndthinkick(Pos<T>& pos, const double& length,
       radiation_constant*SQR(1+pos.de)*b2p*(1+irho*rx + (px*px+py*py)/2)*length;
 
     if (quantum_kick_on){
-      double p0 = accelerator.energy/light_speed;
-      double p0_SI = (accelerator.energy/light_speed) * electron_charge;
-      double gamma = accelerator.energy/M0C2;
+      const double p0 = accelerator.energy/light_speed;
+      const double p0_SI = (accelerator.energy/light_speed) * electron_charge;
+      const double gamma = accelerator.energy/M0C2;
       
       T dl_ds = (1 + rx*irho);
 
@@ -185,7 +186,7 @@ void bndthinkick(Pos<T>& pos, const double& length,
         * pow(abs(irho), 3)*pow(p0, 2)*p0_SI*dl_ds/pow(accelerator.energy, 2) *
         (length/KICK2);
 
-      T qkick = sqrt(d) * random_normal(0., 1.);
+      T qkick = sqrt(d) * random_number;
 
       pos.de += qkick;
     }
@@ -303,6 +304,12 @@ Status::type pm_bnd_mpole_symplectic4_pass(Pos<T> &pos, const Element &elem,
   double irho = elem.angle / elem.length;
   const std::vector<double> &polynom_a = elem.polynom_a;
   const std::vector<double> &polynom_b = elem.polynom_b;
+  //Necessary utils for quantum diffusion
+  double rn = 0;
+  std::random_device rand_dev;
+  std::mt19937  generator(rand_dev());
+  // std::mt19937  generator;
+  std::normal_distribution<double>  distr(0., 1.);
 
   global_2_local(pos, elem);
   edge_fringe(pos, irho, elem.angle_in, elem.fint_in, elem.gap);
@@ -310,7 +317,11 @@ Status::type pm_bnd_mpole_symplectic4_pass(Pos<T> &pos, const Element &elem,
     drift<T>(pos, l1);
     bndthinkick<T>(pos, k1, polynom_a, polynom_b, irho, accelerator, false);
     drift<T>(pos, l2);
-    bndthinkick<T>(pos, k2, polynom_a, polynom_b, irho, accelerator, accelerator.quantdiff_on);
+    if (accelerator.quantdiff_on){
+      rn = distr(generator);
+    }
+    bndthinkick<T>(pos, k2, polynom_a, polynom_b, irho, accelerator,
+    accelerator.quantdiff_on, rn);
     drift<T>(pos, l2);
     bndthinkick<T>(pos, k1, polynom_a, polynom_b, irho, accelerator, false);
     drift<T>(pos, l1);

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -128,7 +128,7 @@ void strthinkick(Pos<T>& pos, const double& length,
                  const std::vector<double>& polynom_a,
                  const std::vector<double>& polynom_b,
                  const Accelerator& accelerator,
-                 const double d_factor=0) {
+                 const double d_factor = 0) {
 
   T real_sum, imag_sum;
   calcpolykick<T>(pos, polynom_a, polynom_b, real_sum, imag_sum);
@@ -166,7 +166,7 @@ void bndthinkick(Pos<T>& pos, const double& length,
                  const std::vector<double>& polynom_b,
                  const double& irho,
                  const Accelerator& accelerator,
-                 const double d_factor=0) {
+                 const double d_factor = 0) {
 
   T real_sum, imag_sum;
   calcpolykick<T>(pos, polynom_a, polynom_b, real_sum, imag_sum);
@@ -281,7 +281,7 @@ Status::type pm_str_mpole_symplectic4_pass(Pos<T> &pos, const Element &elem,
   double k2 = sl * KICK2;
   const std::vector<double> &polynom_a = elem.polynom_a;
   const std::vector<double> &polynom_b = elem.polynom_b;
-  double d_factor=0; // quantum excitation scale factor
+  double d_factor = 0; // quantum excitation scale factor
 
   if (accelerator.quantdiff_on){
     const double p0 = accelerator.energy/light_speed;

--- a/src/accelerator.cpp
+++ b/src/accelerator.cpp
@@ -32,6 +32,7 @@ bool Accelerator::operator==(const Accelerator& o) const {
   if (this->energy != o.energy) return false;
   if (this->cavity_on != o.cavity_on) return false;
   if (this->radiation_on != o.radiation_on) return false;
+  if (this-> quantdiff_on != o.quantdiff_on) return false;
   if (this->vchamber_on != o.vchamber_on) return false;
   if (this->harmonic_number != o.harmonic_number) return false;
   if (this->lattice != o.lattice) return false;
@@ -45,6 +46,7 @@ std::ostream& operator<< (std::ostream &out, const Accelerator& a) {
   out <<              "energy         : " << a.energy;
   out << std::endl << "cavity_on      : " << a.cavity_on;
   out << std::endl << "radiation_on   : " << a.radiation_on;
+  out << std::endl << "quantdiff_on   : " << a.quantdiff_on;
   out << std::endl << "vchamber_on    : " << a.vchamber_on;
   out << std::endl << "harmonic_number: " << a.harmonic_number;
   out << std::endl << "lattice        : " << a.lattice.size() << " elements";

--- a/src/accelerator.cpp
+++ b/src/accelerator.cpp
@@ -32,7 +32,6 @@ bool Accelerator::operator==(const Accelerator& o) const {
   if (this->energy != o.energy) return false;
   if (this->cavity_on != o.cavity_on) return false;
   if (this->radiation_on != o.radiation_on) return false;
-  if (this-> quantdiff_on != o.quantdiff_on) return false;
   if (this->vchamber_on != o.vchamber_on) return false;
   if (this->harmonic_number != o.harmonic_number) return false;
   if (this->lattice != o.lattice) return false;
@@ -46,7 +45,6 @@ std::ostream& operator<< (std::ostream &out, const Accelerator& a) {
   out <<              "energy         : " << a.energy;
   out << std::endl << "cavity_on      : " << a.cavity_on;
   out << std::endl << "radiation_on   : " << a.radiation_on;
-  out << std::endl << "quantdiff_on   : " << a.quantdiff_on;
   out << std::endl << "vchamber_on    : " << a.vchamber_on;
   out << std::endl << "harmonic_number: " << a.harmonic_number;
   out << std::endl << "lattice        : " << a.lattice.size() << " elements";

--- a/src/auxiliary.cpp
+++ b/src/auxiliary.cpp
@@ -16,10 +16,15 @@
 
 #include <trackcpp/auxiliary.h>
 
+static std::random_device rand_dev;
+static std::mt19937 generator(rand_dev());
+static std::normal_distribution<double>  distr(0., 1.);
+
+void set_random_seed(unsigned rnd_seed) {
+    generator.seed(rnd_seed);
+}
+
 double gen_random_number() {
-  static std::random_device rand_dev;
-  static std::mt19937  generator(rand_dev());
-  static std::normal_distribution<double>  distr(0., 1.);
   return distr(generator);
   // Box-Muller Transform
   //

--- a/src/auxiliary.cpp
+++ b/src/auxiliary.cpp
@@ -18,14 +18,30 @@
 
 static std::random_device rand_dev;
 static std::mt19937 generator(rand_dev());
-static std::normal_distribution<double>  distr(0., 1.);
+static std::normal_distribution<double>  distr_gauss(0., 1.);
+static std::uniform_real_distribution<double> distr_uniform(-sqrt(3.0), sqrt(3.0));
+int choosen_distribution = Distributions::normal;
+
+void set_random_distribution(unsigned value){
+  if (value == Distributions::normal){
+    choosen_distribution = value;
+  }else if (value == Distributions::uniform){
+    choosen_distribution = value;
+  }else{
+    std::cout<<"Not valid input"<<"\n";
+  }
+}
 
 void set_random_seed(unsigned rnd_seed) {
     generator.seed(rnd_seed);
 }
 
 double gen_random_number() {
-  return distr(generator);
+  if (choosen_distribution==Distributions::uniform){
+    return distr_uniform(generator);
+  }else{
+    return distr_gauss(generator);
+  }
   // Box-Muller Transform
   //
   // z1 = sqrt(-2*ln(u1)) * cos(2*pi*u2)

--- a/src/auxiliary.cpp
+++ b/src/auxiliary.cpp
@@ -1,0 +1,31 @@
+// TRACKCPP - Particle tracking code
+// Copyright (C) 2015  LNLS Accelerator Physics Group
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <trackcpp/auxiliary.h>
+
+double gen_random_number() {
+  static std::random_device rand_dev;
+  static std::mt19937  generator(rand_dev());
+  static std::normal_distribution<double>  distr(0., 1.);
+  return distr(generator);
+  // Box-Muller Transform
+  //
+  // z1 = sqrt(-2*ln(u1)) * cos(2*pi*u2)
+  // z2 = sqrt(-2*ln(u1)) * sin(2*pi*u2)
+  //
+  // u1, u2: uniform [0, 1]
+  // z1, z2: normal dist.
+}

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -91,7 +91,7 @@ int cmd_dynap_xy(const std::vector<std::string>& args) {
   accelerator.energy = ring_energy;
   accelerator.harmonic_number = harmonic_number;
   accelerator.cavity_on = (cavity_state == "on");
-  accelerator.radiation_on = (radiation_state == "on");
+  accelerator.radiation_on = (radiation_state == "on") ? RadiationState::damping : RadiationState::off;
   accelerator.vchamber_on = (vchamber_state == "on");
 
   // calcs dynamical aperture
@@ -177,7 +177,7 @@ int cmd_dynap_ex(const std::vector<std::string>& args) {
   accelerator.energy = ring_energy;
   accelerator.harmonic_number = harmonic_number;
   accelerator.cavity_on = (cavity_state == "on");
-  accelerator.radiation_on = (radiation_state == "on");
+  accelerator.radiation_on = (radiation_state == "on") ? RadiationState::damping : RadiationState::off;
   accelerator.vchamber_on = (vchamber_state == "on");
 
   // calcs dynamical aperture
@@ -369,7 +369,7 @@ int cmd_dynap_acceptance(const std::vector<std::string>& args) {
   accelerator.energy = ring_energy;
   accelerator.harmonic_number = harmonic_number;
   accelerator.cavity_on = (cavity_state == "on");
-  accelerator.radiation_on = (radiation_state == "on");
+  accelerator.radiation_on = (radiation_state == "on") ? RadiationState::damping : RadiationState::off;
   accelerator.vchamber_on = (vchamber_state == "on");
 
   // calcs dynamical aperture
@@ -910,7 +910,7 @@ int cmd_dynap_xyfmap(const std::vector<std::string>& args) {
   accelerator.energy = ring_energy;
   accelerator.harmonic_number = harmonic_number;
   accelerator.cavity_on = (cavity_state == "on");
-  accelerator.radiation_on = (radiation_state == "on");
+  accelerator.radiation_on = (radiation_state == "on") ? RadiationState::damping : RadiationState::off;
   accelerator.vchamber_on = (vchamber_state == "on");
 
   // calcs dynamical aperture
@@ -993,7 +993,7 @@ int cmd_dynap_exfmap(const std::vector<std::string>& args) {
   accelerator.energy = ring_energy;
   accelerator.harmonic_number = harmonic_number;
   accelerator.cavity_on = (cavity_state == "on");
-  accelerator.radiation_on = (radiation_state == "on");
+  accelerator.radiation_on = (radiation_state == "on") ? RadiationState::damping : RadiationState::off;
   accelerator.vchamber_on = (vchamber_state == "on");
 
   // calcs dynamical aperture
@@ -1076,7 +1076,7 @@ int cmd_track_linepass(const std::vector<std::string>& args) {
   accelerator.energy = ring_energy;
   accelerator.harmonic_number = harmonic_number;
   accelerator.cavity_on = (cavity_state == "on");
-  accelerator.radiation_on = (radiation_state == "on");
+  accelerator.radiation_on = (radiation_state == "on") ? RadiationState::damping : RadiationState::off;
   accelerator.vchamber_on = (vchamber_state == "on");
 
   // does tracking

--- a/src/diffusion_matrix.cpp
+++ b/src/diffusion_matrix.cpp
@@ -118,7 +118,7 @@ void thinkick_symplectic(const Pos<double>& pos, Matrix& bdiff,
 
 void thinkick_rad(Pos<double>& pos, Matrix& bdiff, const Vector& pol_a,
                 const Vector& pol_b, const double frac, const double irho,
-                const int max_order, const double energy, const bool radon){
+                const int max_order, const double energy, const int radon){
 
   const double CRAD = CGAMMA * energy * energy * energy / (TWOPI*1e27);
   const double p_norm = (1+pos.de);
@@ -179,7 +179,7 @@ void thinkick_rad(Pos<double>& pos, Matrix& bdiff, const Vector& pol_a,
 
 // Find Ohmi's diffusion matrix b_diff of a thick multipole.
 void propagate_b_diff(const Element& ele, const Pos<double>& pos,
-                      const double energy, const bool radon, Matrix& bdiff) {
+                      const double energy, const int radon, Matrix& bdiff) {
 
   const double irho = ele.angle / ele.length;
   const std::vector<double>& pola = ele.polynom_a;
@@ -236,7 +236,7 @@ Status::type track_diffusionmatrix (const Accelerator& accelerator,
   Status::type status  = Status::success;
   const std::vector<Element>& lattice = accelerator.lattice;
   const double energy = accelerator.energy;
-  const bool radon = accelerator.radiation_on;
+  const int radon = accelerator.radiation_on;
 
   Pos<double> fp = fixed_point;
 

--- a/src/diffusion_matrix.cpp
+++ b/src/diffusion_matrix.cpp
@@ -141,15 +141,15 @@ void thinkick_rad(Pos<double>& pos, Matrix& bdiff, const Vector& pol_a,
 
   // calculate |B x n|^3 - the third power of the B field component
   // orthogonal to the normalized velocity vector n
-  const double& b2p = b2_perp(
-    im_sum, re_sum+irho, pos.rx, xl, pos.ry, yl, irho);
+  const double& curv = 1 + pos.rx*irho;
+  const double& b2p = b2_perp(im_sum, re_sum+irho, xl, yl, curv);
   const double& b3p = b2p*std::sqrt(b2p);
 
   const double& gamma = energy/M0C2;
   const double& gamma2 = gamma*gamma;
   const double& gamma4 = gamma2*gamma2;
   const double& bb_ = CU*CER*LAMBDABAR*gamma*gamma4*frac*b3p*p_norm2*p_norm2 *
-                      (1 + pos.rx*irho + (xl*xl + yl*yl)/2);
+                      (curv + (xl*xl + yl*yl)/2);
 
   // Add rad kick to bdiff
   bdiff[1][1] += bb_*xl*xl;

--- a/src/flat_file.cpp
+++ b/src/flat_file.cpp
@@ -85,6 +85,7 @@ void write_flat_file_trackcpp(std::ostream& fp, const Accelerator& accelerator) 
   fp << std::setw(hw) << "% harmonic_number" << accelerator.harmonic_number << "\n";
   fp << std::setw(hw) << "% cavity_on" << get_boolean_string(accelerator.cavity_on) << "\n";
   fp << std::setw(hw) << "% radiation_on" << get_boolean_string(accelerator.radiation_on) << "\n";
+  fp << std::setw(hw) << "% quantdiff_on" << get_boolean_string(accelerator.quantdiff_on) << "\n";
   fp << std::setw(hw) << "% vchamber_on" << get_boolean_string(accelerator.vchamber_on) << "\n";
   fp << '\n';
 
@@ -184,6 +185,7 @@ Status::type read_flat_file_trackcpp(std::istream& fp, Accelerator& accelerator)
       if (cmd.compare("harmonic_number") == 0) { ss >> accelerator.harmonic_number; continue; }
       if (cmd.compare("cavity_on") == 0) { accelerator.cavity_on = read_boolean_string(ss); continue; }
       if (cmd.compare("radiation_on") == 0) { accelerator.radiation_on = read_boolean_string(ss); continue; }
+      if (cmd.compare("quantdiff_on") == 0) { accelerator.quantdiff_on = read_boolean_string(ss); continue; }
       if (cmd.compare("vchamber_on") == 0) { accelerator.vchamber_on = read_boolean_string(ss); continue; }
       continue;
     }

--- a/src/flat_file.cpp
+++ b/src/flat_file.cpp
@@ -26,6 +26,7 @@ static const int hw = 18; // header field width
 static const int pw = 16; // parameter field width
 static const int np = 17; // number precision
 static bool read_boolean_string(std::istringstream& ss);
+static int process_rad_property(std::istringstream& ss);
 static std::string get_boolean_string(bool value);
 static bool has_t_vector(const double* t);
 static bool has_r_matrix(const double* r);
@@ -84,8 +85,7 @@ void write_flat_file_trackcpp(std::ostream& fp, const Accelerator& accelerator) 
   fp << std::setw(hw) << "% energy" << accelerator.energy << " eV\n";
   fp << std::setw(hw) << "% harmonic_number" << accelerator.harmonic_number << "\n";
   fp << std::setw(hw) << "% cavity_on" << get_boolean_string(accelerator.cavity_on) << "\n";
-  fp << std::setw(hw) << "% radiation_on" << get_boolean_string(accelerator.radiation_on) << "\n";
-  fp << std::setw(hw) << "% quantdiff_on" << get_boolean_string(accelerator.quantdiff_on) << "\n";
+  fp << std::setw(hw) << "% radiation_on" << accelerator.radiation_on << "\n";
   fp << std::setw(hw) << "% vchamber_on" << get_boolean_string(accelerator.vchamber_on) << "\n";
   fp << '\n';
 
@@ -184,8 +184,8 @@ Status::type read_flat_file_trackcpp(std::istream& fp, Accelerator& accelerator)
       if (cmd.compare("energy") == 0) { ss >> accelerator.energy; continue; }
       if (cmd.compare("harmonic_number") == 0) { ss >> accelerator.harmonic_number; continue; }
       if (cmd.compare("cavity_on") == 0) { accelerator.cavity_on = read_boolean_string(ss); continue; }
-      if (cmd.compare("radiation_on") == 0) { accelerator.radiation_on = read_boolean_string(ss); continue; }
-      if (cmd.compare("quantdiff_on") == 0) { accelerator.quantdiff_on = read_boolean_string(ss); continue; }
+      // radiation_on needs its own processing function due backward compatibility
+      if (cmd.compare("radiation_on") == 0){ accelerator.radiation_on = process_rad_property(ss); continue; }
       if (cmd.compare("vchamber_on") == 0) { accelerator.vchamber_on = read_boolean_string(ss); continue; }
       continue;
     }
@@ -452,6 +452,18 @@ static bool read_boolean_string(std::istringstream& ss) {
     return true;
   else
     return false;
+}
+
+static int process_rad_property(std::istringstream& ss){
+  std::string s;
+  ss >> s;
+  if (std::isdigit(s[0])){
+    return std::stoi(s);
+  }else if(s.compare("true") == 0){
+    return 1;
+  }else{
+    return 0;
+  }
 }
 
 static std::string get_boolean_string(bool value) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -40,7 +40,7 @@ Status::type print_closed_orbit(const Accelerator& accelerator, const std::vecto
 	fprintf(fp, "# ebeam_energy[eV] : %f\n", accelerator.energy);
 	fprintf(fp, "# harmonic_number  : %i\n", accelerator.harmonic_number);
 	fprintf(fp, "# cavity_state     : %s\n", accelerator.cavity_on ? "on" : "off");
-	fprintf(fp, "# radiation_state  : %s\n", accelerator.radiation_on ? "on" : "off");
+	fprintf(fp, "# radiation_state  : %s\n", rad_dict[accelerator.radiation_on]);
 	fprintf(fp, "# chamber_state    : %s\n", accelerator.vchamber_on ? "on" : "off");
 	fprintf(fp, "\n");
 	fprintf(fp, "%-5s %-15s %-24s %-24s %-24s %-24s %-24s %-24s %-24s\n", "# idx", "fam_name", "s[m]", "rx[m]", "px[rad]", "ry[m]", "py[rad]", "de", "dl[m]");
@@ -70,7 +70,7 @@ Status::type print_tracking_linepass(const Accelerator& accelerator, const std::
 	fprintf(fp, "# ebeam_energy[eV]  : %f\n", accelerator.energy);
 	fprintf(fp, "# harmonic_number   : %i\n", accelerator.harmonic_number);
 	fprintf(fp, "# cavity_state      : %s\n", accelerator.cavity_on ? "on" : "off");
-	fprintf(fp, "# radiation_state   : %s\n", accelerator.radiation_on ? "on" : "off");
+	fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on]);
 	fprintf(fp, "# chamber_state     : %s\n", accelerator.vchamber_on ? "on" : "off");
 	fprintf(fp, "\n");
 
@@ -104,7 +104,7 @@ Status::type print_tracking_ringpass(const Accelerator& accelerator, const std::
 	fprintf(fp, "# ebeam_energy[eV]  : %f\n", accelerator.energy);
 	fprintf(fp, "# harmonic_number   : %i\n", accelerator.harmonic_number);
 	fprintf(fp, "# cavity_state      : %s\n", accelerator.cavity_on ? "on" : "off");
-	fprintf(fp, "# radiation_state   : %s\n", accelerator.radiation_on ? "on" : "off");
+	fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on]);
 	fprintf(fp, "# chamber_state     : %s\n", accelerator.vchamber_on ? "on" : "off");
 	fprintf(fp, "\n");
 
@@ -135,7 +135,7 @@ Status::type print_dynapgrid(const Accelerator& accelerator, const std::vector<D
 	fprintf(fp, "# ebeam_energy[eV]  : %f\n", accelerator.energy);
 	fprintf(fp, "# harmonic_number   : %i\n", accelerator.harmonic_number);
 	fprintf(fp, "# cavity_state      : %s\n", accelerator.cavity_on ? "on" : "off");
-	fprintf(fp, "# radiation_state   : %s\n", accelerator.radiation_on ? "on" : "off");
+	fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on]);
 	fprintf(fp, "# chamber_state     : %s\n", accelerator.vchamber_on ? "on" : "off");
 	fprintf(fp, "\n");
 	if (print_tunes) {

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -115,7 +115,7 @@ int test_findorbit4() {
   std::string fname("/home/fac_files/code/trackcpp/tests/si_v07_c05.txt");
   read_flat_file(fname, accelerator);
   accelerator.cavity_on = false;
-  accelerator.radiation_on = false;
+  accelerator.radiation_on = RadiationState::off;
   accelerator.vchamber_on = false;
 
   accelerator.lattice[10].polynom_b[0] = 1e-3;
@@ -138,7 +138,7 @@ int test_findorbit6() {
   std::string fname("/home/fac_files/code/trackcpp/tests/si_v07_c05.txt");
   read_flat_file(fname, accelerator);
   accelerator.cavity_on = true;
-  accelerator.radiation_on = true;
+  accelerator.radiation_on = RadiationState::damping;
   accelerator.vchamber_on = false;
 
   std::vector<Pos<double> > orbit;
@@ -330,7 +330,7 @@ int test_simple_drift() {
 
   accelerator.energy = 3e9; // [ev]
   accelerator.harmonic_number = 864;
-  accelerator.radiation_on = false;
+  accelerator.radiation_on = RadiationState::off;
   accelerator.cavity_on = false;
   accelerator.vchamber_on = false;
 
@@ -358,7 +358,7 @@ int test_simple_quadrupole() {
 
   accelerator.energy = 3e9; // [ev]
   accelerator.harmonic_number = 864;
-  accelerator.radiation_on = false;
+  accelerator.radiation_on = RadiationState::off;
   accelerator.cavity_on = false;
   accelerator.vchamber_on = false;
 
@@ -385,7 +385,7 @@ int test_linepass2() {
   //sirius_v500(accelerator.lattice);
   accelerator.energy = 3e9; // [ev]
   accelerator.harmonic_number = 864;
-  accelerator.radiation_on = false;
+  accelerator.radiation_on = RadiationState::off;
   accelerator.cavity_on = false;
   accelerator.vchamber_on = false;
 
@@ -425,7 +425,7 @@ int test_flatfile() {
   accelerator.energy = 0.0;
   accelerator.harmonic_number = 0;
   accelerator.cavity_on = false;
-  accelerator.radiation_on = false;
+  accelerator.radiation_on = RadiationState::off;
   accelerator.vchamber_on = false;
 
 
@@ -457,7 +457,7 @@ int test_calc_twiss() {
   }
 
   accelerator.cavity_on = true;
-  accelerator.radiation_on = true;
+  accelerator.radiation_on = RadiationState::damping;
   accelerator.vchamber_on = false;
 
   Pos<double> fixed_point_guess;
@@ -551,7 +551,7 @@ int test_new_write_flat_file() {
 
 
   accelerator.cavity_on = true;
-  accelerator.radiation_on = true;
+  accelerator.radiation_on = RadiationState::damping;
   accelerator.vchamber_on = false;
 
   std::string a;

--- a/tests/si_v07_c05.txt
+++ b/tests/si_v07_c05.txt
@@ -3,7 +3,7 @@
 % energy 3000000000.000000 eV
 % harmonic_number 864 
 % cavity_on false 
-% radiation_on false 
+% radiation_on 0 
 % vchamber_on false 
 
 ### 0000 ###

--- a/tests/test-kickmap.cpp
+++ b/tests/test-kickmap.cpp
@@ -42,7 +42,7 @@ int main() {
     accelerator.energy = 2.99792462e9;
     accelerator.harmonic_number = 864;
     accelerator.cavity_on = true;
-    accelerator.radiation_on = true;
+    accelerator.radiation_on = RadiationState::damping;
     accelerator.vchamber_on = true;
 
 


### PR DESCRIPTION
## Introduction
This PR contains a set of modifications in the TrackCPP structure to implement the quantum excitation (or quantum diffusion) in our tracking algorithms. Including this effect will make it possible to reach equilibrium conditions by particle tracking. The related PR in Pyaccel is: https://github.com/lnls-fac/pyaccel/pull/113

In `trackcpp`, the `radiation_on` property was changed to accept the integers `0, 1, or 2`, with each number meaning a different radiation state: `no radiation`, `damping` and `damping+quantum excitation`, respectively.

In Pyaccel, it is possible to set the property with an integer, string, or a boolean (due to backward compatibility), with the following options:

- 0, False, "off"    = No radiative effects.
- 1, True, "damping" = Turns on radiation damping, without quantum excitation.
- 2, "full" = Turns on radiation damping with quantum excitation

The random quantum kicks can be generated from a `normal` distribution or from a `uniform` distribution. In Pyaccel, this can be controlled by the function `pyaccel.utils.set_distribution`. It is also possible to set a seed in the pseudo-random number generator with `pyaccel.utils.set_random_seed`, allowing the repeatability of the simulations. By default, the distribution is `'normal'` and the seed is randomly chosen.

In the following sections, I will show some performance tests and the results of some simulations.

## Performance Tests

In addition to the inclusion of radiation effects, some pass methods were refactored to improve the tracking performance and reduce the simulation time. Special thanks to @fernandohds564, responsible for the great part of this refactorization, and to @xresende who helped to build a fast random number generator.

The below table shows the meantime to simulate a single particle for 500 turns in the SIRIUS lattice for different configurations of radiative effects. The mean was computed over 10 simulations and the uncertainty corresponds to the standard deviation.

<div align="center">

| Radiative effects      | Time (New pass methods) |   Time (Old pass methods)
| :-----------: | :-----------: |  :-----------: |
| No radiative effect      | 660 +/- 50 ms |  740 +/- 40 ms |
| Radiation damping     |  960 +/- 50 ms |  1010 +/- 30 ms| 
| Rad. Damping + Quant. Diffusion (uniform)     | 1100 +/- 80 ms | --- |
| Rad. Damping + Quant. Diffusion (normal)     | 1380 +/- 80 ms | --- |

</div>


CPU details: 

- RAM: 15.5 GiB
- Processor: Intel® Core™ i7-8700 CPU @ 3.20GHz × 12
- Graphics: Intel® UHD Graphics 630 (CFL GT2)

## Convergence to equilibrium parameters

The following Figure shows the beam's second momenta evolution in the SIRIUS model with fitted coupling and vertical dispersion (https://github.com/lnls-fac/pymodels/pull/85). The simulation was carried out with 2000 particles for 25000 turns, with all particles starting from the fixed point $\approx$ `[0,0,0,0,0,0]`. The equilibrium values (the straight black lines in the figure) were taken from the equilibrium beam envelope matrix.

#### Normal distributed quantum kicks: 
<p align="center">
<img src="https://user-images.githubusercontent.com/61889205/181601701-8ed1ec3c-9b14-40dd-9196-e8cdb18b30fb.png" width="600">
</p>

#### Uniform distributed quantum kicks: 
<p align="center">
<img src="https://user-images.githubusercontent.com/61889205/184141002-41807eee-fdb2-4532-9001-58fdc2ee0083.png" width="600">
</p>

The non-diagonal terms of the beam envelope matrix were observed to oscillate around the equilibrium values. To express the oscillation amplitude in terms of more intuitive quantities, they were normalized by the correspondent diagonal terms (normalized covariance):

$$
R_{ij} = \frac{\sigma^2_{i, j}}{\sqrt{\sigma^2_{i, i} \sigma^2_{j, j}}},
$$

which ranges from -1 to 1. $i$ and $j$ are any 6D phase space coordinates pair. The results are shown below.

#### Normal distributed quantum kicks: 
![non_diagonal](https://user-images.githubusercontent.com/61889205/181601798-a3c4cc14-c540-453e-ad02-d369e5742fd1.png)

#### Uniform distributed quantum kicks:
![non_diagonal](https://user-images.githubusercontent.com/61889205/184141312-dea35271-3cd3-4507-b015-7d7b9f25418e.png)

 
## Excitation rate and damping times fitting.

The above simulation was repeated in a model without coupling and for fewer turns (5000). In the absence of coupling, the beam size growth and the energy deviation evolution are simply described by the following equations:

$$
\frac{d(\sigma_x^2)}{dt} = (\frac{Q_x\beta_x}{2} - \frac{2\sigma_x^2}{\tau_x}) 
$$

$$
\frac{d(\sigma_{\delta}^2)}{dt} = (\frac{Q_{\epsilon}}{2 E_0^2} - \frac{2\sigma_{\delta}^2}{\tau_\epsilon})
$$

I integrated them and fitted $Q_x$, $Q_{\epsilon}$ and the damping times. The Figures below show the results:

Beam horizontal size          |  Energy deviation
:-------------------------:|:-------------------------:
![sigmax_fitting](https://user-images.githubusercontent.com/61889205/179758654-126de02a-1d90-4f96-bb1f-78ecf73c325f.png) |  ![sigmae_fitting](https://user-images.githubusercontent.com/61889205/179758687-3c3930e6-94a8-4dce-8029-d60c710107e0.png)

Comparing the obtained values with the nominal values:

<div align="center">

|Quantity     | Fitting  | Nominal |   
| :-----------: | :-----------: |  :-----------: |
| $Q_x$  [ pm/s]      | 0.532 |  0.598 |
| $\tau_x$  [ ms]    |  19.4 |  16.8 |
| $Q_{\epsilon}$  [MeV^2/s]    | 2.058 |  2.029  |
| $\tau_{\epsilon}$  [ms]    | 16.2 |  12.8  |

</div>
The low precision in fitting the damping times can be justified by the fact that quantum excitation dominates over radiation damping for the applied initial conditions.