### PR TITLE
Fix electron rest energy in [eV] precision 

### DIFF
--- a/include/trackcpp/accelerator.h
+++ b/include/trackcpp/accelerator.h
@@ -25,7 +25,7 @@
 //struct Accelerator {
 class Accelerator {
 public:
-  // energy < electron_rest_energy -> energy = electron_rest_energy:
+  // energy < electron_rest_energy_eV -> energy = electron_rest_energy_eV:
   Accelerator(const double& energy=-1);
   double                  energy;              // [eV]
   bool                    cavity_on = false;

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -187,9 +187,9 @@ const double electron_charge          = 1.602176634e-19;   // [C]     - definiti
 const double reduced_planck_constant  = 1.054571817e-34;   // [J.s]   - definition
 const double electron_mass            = 9.1093837015e-31;  // [Kg]    - 2022-03-19 - https://physics.nist.gov/cgi-bin/cuu/Value?me|search_for=electron+mass
 const double vacuum_permeability      = 1.25663706212e-6;  // [T.m/A] - 2022-03-19 - https://physics.nist.gov/cgi-bin/cuu/Value?mu0|search_for=vacuum+permeability
-const double electron_rest_energy     = electron_mass * pow(light_speed,2);             // [Kg.m^2/s^2] - derived
+const double electron_rest_energy     = electron_mass * pow(light_speed,2);      // [Kg.m^2/s^2] - derived
+const double electron_rest_energy_eV  = electron_rest_energy / electron_charge;  // [eV] - derived
 const double vacuum_permitticity      = 1/(vacuum_permeability * pow(light_speed,2));   // [V.s/(A.m)]  - derived
-const double electron_rest_energy_MeV = (electron_rest_energy / electron_charge) / 1e6; // [MeV] - derived
 const double electron_radius          = pow(electron_charge,2)/(4*M_PI*vacuum_permitticity*electron_rest_energy); // [m] - derived
 
 template <typename T>

--- a/include/trackcpp/passmethods.h
+++ b/include/trackcpp/passmethods.h
@@ -43,7 +43,7 @@ const double KICK2 = -0.1702414383919314656e01;
 #else
   const double TWOPI_ = 2*M_PI;
   const double CGAMMA_ = 4*M_PI*electron_radius/pow(electron_rest_energy/electron_charge/1e9,3)/3;
-  const double M0C2 = electron_rest_energy_MeV * 1e6;
+  const double M0C2 = electron_rest_energy_eV;
   const double LAMBDABAR = reduced_planck_constant / light_speed / electron_mass;
   const double CER = electron_radius;
   const double CU = 55/(24*std::sqrt(3));

--- a/src/accelerator.cpp
+++ b/src/accelerator.cpp
@@ -18,7 +18,7 @@
 #include <trackcpp/auxiliary.h>
 
 Accelerator::Accelerator(const double& energy) {
-  this->energy = (energy < electron_rest_energy_MeV*1e6) ? electron_rest_energy_MeV*1e6 : energy;
+  this->energy = (energy < electron_rest_energy_eV) ? electron_rest_energy_eV : energy;
 }
 
 double Accelerator::get_length() const {

--- a/src/optics.cpp
+++ b/src/optics.cpp
@@ -18,7 +18,7 @@
 #include <trackcpp/linalg.h>
 
 double get_magnetic_rigidity(const double energy) {
-    double gamma = (energy/1e6) / (electron_rest_energy_MeV);
+    double gamma = energy / electron_rest_energy_eV;
     double beta  = sqrt(1 - 1/(gamma*gamma));
     double b_rho = beta * energy / light_speed; // [T.m]
     return b_rho;


### PR DESCRIPTION
The present changes increase (fix) the electron rest energy in [eV] units.

The electron rest energy constant in trackcpp has 2 definitions: one in [kg*m^2/s^2] and other in [MeV]. The MeV definition is used in the creation of Accelerator objects. When the Accelerator's constructor is called and the energy argument isnt passed or is below the electron rest energy, for example: ```acc = trackcpp.Accelerator()``` -> the constructor uses ```energy=-1```, then it checks if 
```-1 < electron_rest_energy_MeV*1e6```
, finally, if `true`, it sets the accelerator's energy equal to ```electron_rest_energy_MeV*1e6``` that implies in a lost of precision (the mantissa lose its last right digit).

To fix it, was created a new constant `electron_rest_energy_eV` to replace the `electron_rest_energy_MeV`, recovering the full precision of it.

This little imprecision was spotted using the Accelerator object constructor in PyAccel, doing: 
```python
import pyaccel
accelerator = pyaccel.accelerator.Accelerator() # the energy must be the electron rest energy
print(accelerator.energy) # it prints: 510998.9499961641
print(accelerator.gamma_factor) # it prints: 0.9999999999999998
```
The expected values for the electron rest energy in eV is `510998.94999616424` and the gamma_factor should be `1.0`.