### PR TITLE
work with t_in, r_in, t_out and r_out as nullptr

### DIFF
--- a/include/trackcpp/elements.h
+++ b/include/trackcpp/elements.h
@@ -68,6 +68,11 @@ public:
   bool has_r_in = false;
   bool has_r_out = false;
 
+  void reflag_t_in(void);
+  void reflag_t_out(void);
+  void reflag_r_in(void);
+  void reflag_r_out(void);
+
   const std::string& get_pass_method();
   void set_pass_method(const std::string& pass_method_);
 

--- a/include/trackcpp/elements.h
+++ b/include/trackcpp/elements.h
@@ -58,10 +58,15 @@ public:
   std::vector<double> polynom_b = default_polynom;
   Matrix              matrix66 = Matrix(6);
 
-  double* t_in;
-  double* t_out;
-  double* r_in;
-  double* r_out;
+  double t_in[6];
+  double t_out[6];
+  double r_in[36];
+  double r_out[36];
+
+  bool has_t_in = false;
+  bool has_t_out = false; 
+  bool has_r_in = false;
+  bool has_r_out = false;
 
   const std::string& get_pass_method();
   void set_pass_method(const std::string& pass_method_);

--- a/include/trackcpp/elements.h
+++ b/include/trackcpp/elements.h
@@ -29,16 +29,6 @@
 class Element {
 public:
 
-//  fam_name(fam_name_), pass_method(PassMethod::pm_drift_pass),
-//    nr_steps(1), length(length_),
-//    hkick(0), vkick(0),
-//    angle(0), angle_in(0), angle_out(0),
-//    gap(0), fint_in(0), fint_out(0),
-//    thin_KL(0), thin_SL(0),
-//    frequency(0), voltage(0), phase_lag(0),
-//    polynom_a(default_polynom), polynom_b(default_polynom),
-//    hmax(DBL_MAX), vmax(DBL_MAX)
-
   std::string   fam_name;
   int           pass_method = PassMethod::pm_drift_pass;
   double        length      = 0;  // [m]
@@ -68,12 +58,13 @@ public:
   std::vector<double> polynom_b = default_polynom;
   Matrix              matrix66 = Matrix(6);
 
-  double              t_in[6],  t_out[6];
-  double              r_in[36], r_out[36];
+  double* t_in;
+  double* t_out;
+  double* r_in;
+  double* r_out;
 
   const std::string& get_pass_method();
   void set_pass_method(const std::string& pass_method_);
-
 
   // default constructor (builds a drift-type element)
   Element(const std::string& fam_name_ = "", const double& length_ = 0);

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -222,7 +222,6 @@ void edge_fringe(Pos<T>& pos, const double& inv_rho,
 
 template <typename T>
 inline void translate_pos(Pos<T> &pos, const double* t) {
-  // std::cout<<"translating"<<std::endl;
   pos.rx += t[0];
   pos.px += t[1];
   pos.ry += t[2];
@@ -233,7 +232,6 @@ inline void translate_pos(Pos<T> &pos, const double* t) {
 
 template <typename T>
 inline void rotate_pos(Pos<T> &pos, const double* R) {
-  // std::cout<<"rotating"<<std::endl;
   const T rx0 = pos.rx, px0 = pos.px;
   const T ry0 = pos.ry, py0 = pos.py;
   const T de0 = pos.de, dl0 = pos.dl;
@@ -244,34 +242,6 @@ inline void rotate_pos(Pos<T> &pos, const double* R) {
   pos.de = R[4*6+0] * rx0 + R[4*6+1] * px0 + R[4*6+2] * ry0 + R[4*6+3] * py0 + R[4*6+4] * de0 + R[4*6+5] * dl0;
   pos.dl = R[5*6+0] * rx0 + R[5*6+1] * px0 + R[5*6+2] * ry0 + R[5*6+3] * py0 + R[5*6+4] * de0 + R[5*6+5] * dl0;
 }
-
-// template <typename T>
-// inline void translate_and_rotate_pos(Pos<T> &pos, const double* t, const double* R) {
-//   // std::cout<<"translating and rotating"<<std::endl;
-//   const T rx0 = pos.rx + t[0], px0 = pos.px + t[1];
-//   const T ry0 = pos.ry + t[2], py0 = pos.py + t[3];
-//   const T de0 = pos.de + t[4], dl0 = pos.dl + t[5];
-//   pos.rx = R[0*6+0] * rx0 + R[0*6+1] * px0 + R[0*6+2] * ry0 + R[0*6+3] * py0 + R[0*6+4] * de0 + R[0*6+5] * dl0;
-//   pos.px = R[1*6+0] * rx0 + R[1*6+1] * px0 + R[1*6+2] * ry0 + R[1*6+3] * py0 + R[1*6+4] * de0 + R[1*6+5] * dl0;
-//   pos.ry = R[2*6+0] * rx0 + R[2*6+1] * px0 + R[2*6+2] * ry0 + R[2*6+3] * py0 + R[2*6+4] * de0 + R[2*6+5] * dl0;
-//   pos.py = R[3*6+0] * rx0 + R[3*6+1] * px0 + R[3*6+2] * ry0 + R[3*6+3] * py0 + R[3*6+4] * de0 + R[3*6+5] * dl0;
-//   pos.de = R[4*6+0] * rx0 + R[4*6+1] * px0 + R[4*6+2] * ry0 + R[4*6+3] * py0 + R[4*6+4] * de0 + R[4*6+5] * dl0;
-//   pos.dl = R[5*6+0] * rx0 + R[5*6+1] * px0 + R[5*6+2] * ry0 + R[5*6+3] * py0 + R[5*6+4] * de0 + R[5*6+5] * dl0;
-// }
-
-// template <typename T>
-// inline void rotate_and_translate_pos(Pos<T> &pos, const double* R, const double* t) {
-//   // std::cout<<"rotating and translating"<<std::endl;
-//   const T rx0 = pos.rx, px0 = pos.px;
-//   const T ry0 = pos.ry, py0 = pos.py;
-//   const T de0 = pos.de, dl0 = pos.dl;
-//   pos.rx = t[0] + R[0*6+0] * rx0 + R[0*6+1] * px0 + R[0*6+2] * ry0 + R[0*6+3] * py0 + R[0*6+4] * de0 + R[0*6+5] * dl0;
-//   pos.px = t[1] + R[1*6+0] * rx0 + R[1*6+1] * px0 + R[1*6+2] * ry0 + R[1*6+3] * py0 + R[1*6+4] * de0 + R[1*6+5] * dl0;
-//   pos.ry = t[2] + R[2*6+0] * rx0 + R[2*6+1] * px0 + R[2*6+2] * ry0 + R[2*6+3] * py0 + R[2*6+4] * de0 + R[2*6+5] * dl0;
-//   pos.py = t[3] + R[3*6+0] * rx0 + R[3*6+1] * px0 + R[3*6+2] * ry0 + R[3*6+3] * py0 + R[3*6+4] * de0 + R[3*6+5] * dl0;
-//   pos.de = t[4] + R[4*6+0] * rx0 + R[4*6+1] * px0 + R[4*6+2] * ry0 + R[4*6+3] * py0 + R[4*6+4] * de0 + R[4*6+5] * dl0;
-//   pos.dl = t[5] + R[5*6+0] * rx0 + R[5*6+1] * px0 + R[5*6+2] * ry0 + R[5*6+3] * py0 + R[5*6+4] * de0 + R[5*6+5] * dl0;
-// }
 
 template <typename T>
 void global_2_local(Pos<T> &pos, const Element &elem) {

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -222,15 +222,18 @@ void edge_fringe(Pos<T>& pos, const double& inv_rho,
 
 template <typename T>
 inline void translate_pos(Pos<T> &pos, const double* t) {
-
-  pos.rx += t[0]; pos.px += t[1];
-  pos.ry += t[2]; pos.py += t[3];
-  pos.de += t[4]; pos.dl += t[5];
+  // std::cout<<"translating"<<std::endl;
+  pos.rx += t[0];
+  pos.px += t[1];
+  pos.ry += t[2];
+  pos.py += t[3];
+  pos.de += t[4];
+  pos.dl += t[5];
 }
 
 template <typename T>
 inline void rotate_pos(Pos<T> &pos, const double* R) {
-
+  // std::cout<<"rotating"<<std::endl;
   const T rx0 = pos.rx, px0 = pos.px;
   const T ry0 = pos.ry, py0 = pos.py;
   const T de0 = pos.de, dl0 = pos.dl;
@@ -242,28 +245,54 @@ inline void rotate_pos(Pos<T> &pos, const double* R) {
   pos.dl = R[5*6+0] * rx0 + R[5*6+1] * px0 + R[5*6+2] * ry0 + R[5*6+3] * py0 + R[5*6+4] * de0 + R[5*6+5] * dl0;
 }
 
+// template <typename T>
+// inline void translate_and_rotate_pos(Pos<T> &pos, const double* t, const double* R) {
+//   // std::cout<<"translating and rotating"<<std::endl;
+//   const T rx0 = pos.rx + t[0], px0 = pos.px + t[1];
+//   const T ry0 = pos.ry + t[2], py0 = pos.py + t[3];
+//   const T de0 = pos.de + t[4], dl0 = pos.dl + t[5];
+//   pos.rx = R[0*6+0] * rx0 + R[0*6+1] * px0 + R[0*6+2] * ry0 + R[0*6+3] * py0 + R[0*6+4] * de0 + R[0*6+5] * dl0;
+//   pos.px = R[1*6+0] * rx0 + R[1*6+1] * px0 + R[1*6+2] * ry0 + R[1*6+3] * py0 + R[1*6+4] * de0 + R[1*6+5] * dl0;
+//   pos.ry = R[2*6+0] * rx0 + R[2*6+1] * px0 + R[2*6+2] * ry0 + R[2*6+3] * py0 + R[2*6+4] * de0 + R[2*6+5] * dl0;
+//   pos.py = R[3*6+0] * rx0 + R[3*6+1] * px0 + R[3*6+2] * ry0 + R[3*6+3] * py0 + R[3*6+4] * de0 + R[3*6+5] * dl0;
+//   pos.de = R[4*6+0] * rx0 + R[4*6+1] * px0 + R[4*6+2] * ry0 + R[4*6+3] * py0 + R[4*6+4] * de0 + R[4*6+5] * dl0;
+//   pos.dl = R[5*6+0] * rx0 + R[5*6+1] * px0 + R[5*6+2] * ry0 + R[5*6+3] * py0 + R[5*6+4] * de0 + R[5*6+5] * dl0;
+// }
+
+// template <typename T>
+// inline void rotate_and_translate_pos(Pos<T> &pos, const double* R, const double* t) {
+//   // std::cout<<"rotating and translating"<<std::endl;
+//   const T rx0 = pos.rx, px0 = pos.px;
+//   const T ry0 = pos.ry, py0 = pos.py;
+//   const T de0 = pos.de, dl0 = pos.dl;
+//   pos.rx = t[0] + R[0*6+0] * rx0 + R[0*6+1] * px0 + R[0*6+2] * ry0 + R[0*6+3] * py0 + R[0*6+4] * de0 + R[0*6+5] * dl0;
+//   pos.px = t[1] + R[1*6+0] * rx0 + R[1*6+1] * px0 + R[1*6+2] * ry0 + R[1*6+3] * py0 + R[1*6+4] * de0 + R[1*6+5] * dl0;
+//   pos.ry = t[2] + R[2*6+0] * rx0 + R[2*6+1] * px0 + R[2*6+2] * ry0 + R[2*6+3] * py0 + R[2*6+4] * de0 + R[2*6+5] * dl0;
+//   pos.py = t[3] + R[3*6+0] * rx0 + R[3*6+1] * px0 + R[3*6+2] * ry0 + R[3*6+3] * py0 + R[3*6+4] * de0 + R[3*6+5] * dl0;
+//   pos.de = t[4] + R[4*6+0] * rx0 + R[4*6+1] * px0 + R[4*6+2] * ry0 + R[4*6+3] * py0 + R[4*6+4] * de0 + R[4*6+5] * dl0;
+//   pos.dl = t[5] + R[5*6+0] * rx0 + R[5*6+1] * px0 + R[5*6+2] * ry0 + R[5*6+3] * py0 + R[5*6+4] * de0 + R[5*6+5] * dl0;
+// }
+
 template <typename T>
 void global_2_local(Pos<T> &pos, const Element &elem) {
-
-  if (elem.t_in != nullptr) {
-    translate_pos(pos, elem.t_in);
-  }
-  if (elem.r_in != nullptr) {
-    rotate_pos(pos, elem.r_in);
-  }
+    if (elem.has_t_in) {
+        translate_pos(pos, elem.t_in);
+    }
+    if (elem.has_r_in) {
+        rotate_pos(pos, elem.r_in);
+    }
 }
 
 template <typename T>
 void local_2_global(Pos<T> &pos, const Element &elem) {
-
-  if (elem.r_out != nullptr) {
-    rotate_pos(pos, elem.r_out);
-  }
-  if (elem.t_out != nullptr) {
-    translate_pos(pos, elem.t_out);
-  }
-  
+    if (elem.has_r_out) {
+        rotate_pos(pos, elem.r_out);
+    }
+    if (elem.has_t_out) {
+        translate_pos(pos, elem.t_out);
+    }
 }
+
 
 template <typename T>
 Status::type pm_identity_pass(Pos<T> &pos, const Element &elem,

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -245,20 +245,20 @@ inline void rotate_pos(Pos<T> &pos, const double* R) {
 
 template <typename T>
 void global_2_local(Pos<T> &pos, const Element &elem) {
-    if (elem.has_t_in) {
+    if (!elem.has_t_in) {} else {
         translate_pos(pos, elem.t_in);
     }
-    if (elem.has_r_in) {
+    if (!elem.has_r_in) {} else {
         rotate_pos(pos, elem.r_in);
     }
 }
 
 template <typename T>
 void local_2_global(Pos<T> &pos, const Element &elem) {
-    if (elem.has_r_out) {
+    if (!elem.has_r_out) {} else {
         rotate_pos(pos, elem.r_out);
     }
-    if (elem.has_t_out) {
+    if (!elem.has_t_out) {} else {
         translate_pos(pos, elem.t_out);
     }
 }

--- a/include/trackcpp/passmethods.hpp
+++ b/include/trackcpp/passmethods.hpp
@@ -245,15 +245,24 @@ inline void rotate_pos(Pos<T> &pos, const double* R) {
 template <typename T>
 void global_2_local(Pos<T> &pos, const Element &elem) {
 
-  translate_pos(pos, elem.t_in);
-  rotate_pos(pos, elem.r_in);
+  if (elem.t_in != nullptr) {
+    translate_pos(pos, elem.t_in);
+  }
+  if (elem.r_in != nullptr) {
+    rotate_pos(pos, elem.r_in);
+  }
 }
 
 template <typename T>
 void local_2_global(Pos<T> &pos, const Element &elem) {
 
-  rotate_pos(pos, elem.r_out);
-  translate_pos(pos, elem.t_out);
+  if (elem.r_out != nullptr) {
+    rotate_pos(pos, elem.r_out);
+  }
+  if (elem.t_out != nullptr) {
+    translate_pos(pos, elem.t_out);
+  }
+  
 }
 
 template <typename T>

--- a/python_package/trackcpp.i
+++ b/python_package/trackcpp.i
@@ -52,6 +52,14 @@ namespace std {
 }
 
 %inline %{
+bool check_is_nullptr(double* v){
+    if (v == nullptr) {return true;}
+    return false;
+}
+double* c_array_create(int arrsize){
+    double* arr = new double[arrsize];
+    return arr;
+}
 double c_array_get(double* v, int i) {
     return v[i];
 }

--- a/python_package/trackcpp.i
+++ b/python_package/trackcpp.i
@@ -18,6 +18,7 @@
 
 %{
 #define SWIG_FILE_WITH_INIT
+#include <vector>
 #include <trackcpp/elements.h>
 #include <trackcpp/kicktable.h>
 #include <trackcpp/auxiliary.h>
@@ -34,7 +35,7 @@
 
 %include "carrays.i"
 %include "std_string.i"
-%include "std_vector.i"
+// %include "std_vector.i"
 %include "stl.i"
 %include "typemaps.i"
 
@@ -52,14 +53,6 @@ namespace std {
 }
 
 %inline %{
-bool check_is_nullptr(double* v){
-    if (v == nullptr) {return true;}
-    return false;
-}
-double* c_array_create(int arrsize){
-    double* arr = new double[arrsize];
-    return arr;
-}
 double c_array_get(double* v, int i) {
     return v[i];
 }
@@ -71,6 +64,13 @@ double get_double_max() {
 }
 
 %}
+
+
+%extend std::vector<double> {
+    double* my_beautiful_pointer() {
+        return $self->data();
+    }
+}
 
 %include "numpy.i"
 

--- a/python_package/trackcpp.i
+++ b/python_package/trackcpp.i
@@ -67,7 +67,7 @@ double get_double_max() {
 
 
 %extend std::vector<double> {
-    double* my_beautiful_pointer() {
+    double* data_() {
         return $self->data();
     }
 }

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -18,6 +18,7 @@
 #include <trackcpp/elements.h>
 #include <trackcpp/kicktable.h>
 #include <cfloat>
+#include <cstring>
 
 
 const std::vector<double> Element::default_polynom = std::vector<double>(3,0);
@@ -294,3 +295,26 @@ void initialize_kickmap(Element& element, const int& kicktable_idx, const int& n
     element.kicktable_idx = kicktable_idx;
     element.rescale_kicks = rescale_kicks;
 }
+
+const double id6[6] = {0, 0, 0, 0, 0, 0};
+const double id66[36] = {
+                          1, 0, 0, 0, 0, 0,
+                          0, 1, 0, 0, 0, 0,
+                          0, 0, 1, 0, 0, 0,
+                          0, 0, 0, 1, 0, 0,
+                          0, 0, 0, 0, 1, 0,
+                          0, 0, 0, 0, 0, 1
+                        };
+
+void Element::reflag_t_in(void){
+  this->has_t_in = std::memcmp(this->t_in, id6, 6*8) ;
+};
+void Element::reflag_t_out(void){
+  this->has_t_out = std::memcmp(this->t_out, id6, 6*8) ;
+};
+void Element::reflag_r_in(void){
+  this->has_r_in = std::memcmp(this->r_in, id66, 36*8) ;
+};
+void Element::reflag_r_out(void){
+  this->has_r_out = std::memcmp(this->r_out, id66, 36*8) ;
+};

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -25,10 +25,23 @@ const std::vector<double> Element::default_polynom = std::vector<double>(3,0);
 
 // default constructor (constructs a drift element)
 Element::Element(const std::string& fam_name_, const double& length_) :
-    fam_name(fam_name_), length(length_),
-    t_in(nullptr), t_out(nullptr),
-    r_in(nullptr), r_out(nullptr) 
-    {matrix66.eye();}
+    fam_name(fam_name_), length(length_)
+    {
+      for (unsigned int i=0; i<6; i++){
+        t_in[i] = 0.0;
+        t_out[i] = 0.0;
+        for (unsigned int j=0; j<6; j++){
+          if (i == j){
+            r_in[i*6+j] = 1.0;
+            r_out[i*6+j] = 1.0;
+          } else {
+            r_in[i*6+j] = 0.0;
+            r_out[i*6+j] = 0.0;
+          }
+        };
+      };
+      matrix66.eye();
+  };
 
 const std::string& Element::get_pass_method() {
     return pm_dict[pass_method];

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -25,19 +25,10 @@ const std::vector<double> Element::default_polynom = std::vector<double>(3,0);
 
 // default constructor (constructs a drift element)
 Element::Element(const std::string& fam_name_, const double& length_) :
-    fam_name(fam_name_), length(length_) {
-  for(unsigned int i=0; i<6; i++) {
-    t_in[i] = t_out[i] = 0.0;
-    for(unsigned int j=0; j<6; ++j) {
-      if (i == j) {
-        r_in[i*6+j] = r_out[i*6+j] = 1.0;
-      } else {
-        r_in[i*6+j] = r_out[i*6+j] = 0.0;
-      }
-    }
-  }
-  matrix66.eye();
-}
+    fam_name(fam_name_), length(length_),
+    t_in(nullptr), t_out(nullptr),
+    r_in(nullptr), r_out(nullptr) 
+    {matrix66.eye();}
 
 const std::string& Element::get_pass_method() {
     return pm_dict[pass_method];


### PR DESCRIPTION
The latest studies with the development of Track.jl showed that the functions of translating and rotating the particle's referential in the tracking with `local2global` and `global2local` can slow down the simulations even if the translation vectors are zero or the rotation matrices are the identity. To enhance it, the elements properties `t_in`, `t_out`, `r_`in and `r_out` will be set as `nullptr` by default. This way, the referential changes will check if the vectors/matrices are null and skip the translation and/or rotation.