### PR TITLE
Return lost position

### DIFF
--- a/include/trackcpp/tracking.h
+++ b/include/trackcpp/tracking.h
@@ -352,8 +352,7 @@ Status::type track_ringpass (
         if ((status = track_linepass (accelerator, orig_pos, final_pos, element_offset, lost_plane, false)) != Status::success) {
 
             // fill last of vector with nans
-            pos.emplace_back(
-                nan(""),nan(""),nan(""),nan(""),nan(""),nan(""));
+            pos.push_back(orig_pos);
             if (trajectory) for(int i=lost_turn+1; i<nr_turns; ++i) {
                     pos.emplace_back(
                         nan(""),nan(""),nan(""),nan(""),nan(""),nan(""));

--- a/include/trackcpp/tracking.h
+++ b/include/trackcpp/tracking.h
@@ -212,7 +212,8 @@ Status::type track_linepass (
 
         if (status != Status::success) {
             // fill rest of vector with nans
-            for(int ii=i+1; ii<=nr_elements; ++ii) {
+            if (indcs[i+1]) pos.push_back(orig_pos);
+            for(int ii=i+2; ii<=nr_elements; ++ii) {
                 if (indcs[ii]) pos.emplace_back(
                     nan(""),nan(""),nan(""),nan(""),nan(""),nan(""));
             }


### PR DESCRIPTION
I need to have access to the position (`rx`, `px`, `ry`, `py`) of the lost particles, in my simulations to know exactly at which transverse position the particle was lost.
Currently this is not possible with `trackcpp`, because it only returns the element, the plane and the turn where the particle was lost.

I tried to add this info making minimal changes to the code, but it comes with some disadvantages and I would like to know your opinion on the matter.
I added the position of the lost particle in the `part_out` output of `line_pass`/`ring_pass`  at the position of the next element/turn. This changes the interpretation of the results of the tracking.

Prior to this PR, this sequence of commands:
```python3
import pyaccel as pa
from pymodels import si

mod = si.create_accelerator()
mod.vchamber_on = True

rin = np.array([0.011, 0.1, 0, 0, 0.0, 0])
out1 = pa.tracking.ring_pass(mod, rin, nr_turns=5, turn_by_turn=True)
out2 = pa.tracking.line_pass(mod, rin, indices='closed')

print(out1[0][:, :5], out1[1:])
print(out2[0][:, :5], out2[1:])
```
would return:
```
[[0.011   nan   nan   nan   nan]
 [0.1     nan   nan   nan   nan]
 [0.      nan   nan   nan   nan]
 [0.      nan   nan   nan   nan]
 [0.      nan   nan   nan   nan]
 [0.      nan   nan   nan   nan]] (True, 0, 2, 'x')
[[0.011 0.011 0.011   nan   nan]
 [0.1   0.1   0.1     nan   nan]
 [0.    0.    0.      nan   nan]
 [0.    0.    0.      nan   nan]
 [0.    0.    0.      nan   nan]
 [0.    0.    0.      nan   nan]] (True, 2, 'x')
```

After this PR, we have the following output:
```
[[0.011      0.20248475        nan        nan        nan]
 [0.1        0.1               nan        nan        nan]
 [0.         0.                nan        nan        nan]
 [0.         0.                nan        nan        nan]
 [0.         0.                nan        nan        nan]
 [0.         0.00957424        nan        nan        nan]] (True, 0, 2, 'x')
[[0.011      0.011      0.011      0.20248475        nan]
 [0.1        0.1        0.1        0.1               nan]
 [0.         0.         0.         0.                nan]
 [0.         0.         0.         0.                nan]
 [0.         0.         0.         0.                nan]
 [0.         0.         0.         0.00957424        nan]] (True, 2, 'x')
```

Note that `ring_pass` returns the position of the lost particle as if it were the position of the particle at the beginning of the second turn, even tough the particle was lost at the beginning of the first turn.
Additionally, `line_pass` returns a position clearly larger than the vacuum chamber limits at the entrance of the next element.

Notice that if we call `ring_pass` with `turn_by_turn=False`, there will be no `nan`'s in `part_out` and the most simple way to check if a given particle was lost is by checking if the output `lost_plane` is equal to `no_plane`. For an example, check the code below:
```python3
rin = np.zeros((6, 2), dtype=float)
rin[:, 1] = np.array([0.011, 0.1, 0, 0, 0.0, 0])
part_out, lost_flag, lost_turn, lost_element, lost_plane = pa.tracking.ring_pass(
    mod, rin, nr_turns=5, turn_by_turn=False
)

lost_part = np.array(lost_plane) != None
print(part_out)
print(lost_part)
```
```
[[0.         0.20248475]
 [0.         0.1       ]
 [0.         0.        ]
 [0.         0.        ]
 [0.         0.        ]
 [0.         0.00957424]]
[False  True]
```


What are your opinions on this, guys?
There are other ways of implementing this feature.
We could, for instance, add another output to `line_pass` and `ring_pass`.