### PR TITLE
Return particles lost positions

### DIFF
--- a/include/trackcpp/dynap.h
+++ b/include/trackcpp/dynap.h
@@ -27,8 +27,8 @@
 struct DynApGridPoint {
   Pos<double>  p;              // Dislocation around closed-orbit
   unsigned int start_element;
-  int lost_turn;
-  int lost_element;
+  unsigned int lost_turn;
+  unsigned int lost_element;
   Plane::type  lost_plane;     // Plane::no_plane,Plane::x,Plane::y,Plane::z
   double       nux1, nuy1;     // tunes at first half number of turns
   double       nux2, nuy2;     // tunes at second half number of turns

--- a/include/trackcpp/dynap.h
+++ b/include/trackcpp/dynap.h
@@ -27,8 +27,8 @@
 struct DynApGridPoint {
   Pos<double>  p;              // Dislocation around closed-orbit
   unsigned int start_element;
-  unsigned int lost_turn;
-  unsigned int lost_element;
+  int lost_turn;
+  int lost_element;
   Plane::type  lost_plane;     // Plane::no_plane,Plane::x,Plane::y,Plane::z
   double       nux1, nuy1;     // tunes at first half number of turns
   double       nux2, nuy2;     // tunes at second half number of turns

--- a/include/trackcpp/tracking.h
+++ b/include/trackcpp/tracking.h
@@ -53,9 +53,10 @@ Pos<double>  linalg_solve6_posvec(
 
 template <typename T>
 Status::type track_elementpass (
-             const Element& el,                 // element through which to track particle
-             Pos<T> &orig_pos,                  // initial electron coordinates
-             const Accelerator& accelerator) {
+    const Accelerator& accelerator,
+    const Element& el, // element through which to track particle
+    Pos<T> &orig_pos // initial electron coordinates
+) {
 
     Status::type status = Status::success;
 
@@ -96,55 +97,56 @@ Status::type track_elementpass (
     default:
         return Status::passmethod_not_defined;
     }
-
     return status;
-
 }
 
 template <typename T>
 Status::type track_elementpass (
-             const Element& el,  // element through which to track particle
-             std::vector<Pos<T> >& orig_pos,  // initial electron coordinates
-             const Accelerator& accelerator) {
-
-    Status::type status  = Status::success;
-
+    const Accelerator& accelerator,
+    const Element& el, // element through which to track particle
+    std::vector<Pos<T> >& orig_pos // initial electron coordinates
+){
+    Status::type status = Status::success;
     for(auto&& pos: orig_pos) {
-        Status::type status2 = track_elementpass(el, pos, accelerator);
+        Status::type status2 = track_elementpass(accelerator, el, pos);
         if (status2 != Status::success) status = status2;
     }
     return status;
 }
-
-
 
 // linepass
 // --------
 // tracks particles along a beam transport line
 //
 // inputs:
-//        line:             Element vector representing the beam transport line
-//        orig_pos:        Pos vector representing initial positions of particles
-//        element_offset:    equivalent to shifting the lattice so that '*element_offset' is the index for the first element
-//        trajectory:        flag indicating that trajectory is to be recorded at entrance of all elements
-//                        (otherwise only the coordinates at the exit of last element is recorded)
+//     accelerator: Element vector representing the beam transport line.
+//     orig_pos: Pos vector representing initial positions of particles.
+//     indices: vector of integers defining at which elements to return.
+//     element_offset: equivalent to shifting the lattice so that
+//         '*element_offset' is the index for the first element.
+//
 // outputs:
-//        pos:            Pos vector of particles' final coordinates (or trajetory)
-//        element_offset:    in case of problems with passmethods, '*element_offset' is the index of the corresponding element
-//        RETURN:            status do tracking (see 'auxiliary.h')
-
+//     element_offset: in case of problems with passmethods, such as particle
+//         loss '*element_offset' is the index of the corresponding element.
+//     pos: Pos vector of particles coordinates at the start of every element
+//         selected by indices and at the end of the last element.
+//     lost_plane: which plane the particle was lost.
+//     lost_pos: return coordinates of lost particle.
+//
+// RETURN:
+//      status do tracking (see 'auxiliary.h')
+//
 template <typename T>
 Status::type track_linepass (
-        const Accelerator& accelerator,
-        Pos<T>& orig_pos,              // initial electron coordinates
-        std::vector<Pos<T> >& pos,     // vector with tracked electron coordinates at start of every element and at the end of last one.
-        unsigned int& element_offset,  // index of starting element for tracking
-        Plane::type& lost_plane,       // return plane in which particle was lost, if the case.
-        std::vector<unsigned int >& indices) {// indices to return;
+    const Accelerator& accelerator,
+    Pos<T>& orig_pos,
+    const std::vector<unsigned int>& indices,
+    unsigned int& element_offset,
+    std::vector<Pos<T> >& pos,
+    Plane::type& lost_plane
+) {
 
     Status::type status = Status::success;
-    lost_plane = Plane::no_plane;
-
     const std::vector<Element>& line = accelerator.lattice;
     int nr_elements  = line.size();
 
@@ -165,56 +167,14 @@ Status::type track_linepass (
         // stores trajectory at entrance of each element
         if (indcs[i]) pos.push_back(orig_pos);
 
-        status = track_elementpass (element, orig_pos, accelerator);
-
-        const T& rx = orig_pos.rx;
-        const T& ry = orig_pos.ry;
-
-        // checks if particle is lost
-        if (not isfinite(rx)) {
-            lost_plane = Plane::x;
-            status = Status::particle_lost;
-        }
-        if (not isfinite(ry)) {
-            if (status != Status::particle_lost) {
-                lost_plane = Plane::y;
-                status = Status::particle_lost;
-            } else {
-                lost_plane = Plane::xy;
-            }
-        }
-        if ((status != Status::particle_lost) and accelerator.vchamber_on) {
-            if (element.vchamber < 0) {
-                // invalid p-norm shape (negative p)
-                // safely signals lost particle
-                lost_plane = Plane::xy;
-                status = Status::particle_lost;
-            } else if (element.vchamber == VChamberShape::rectangle) {
-                // rectangular vacuum chamber
-                if (((rx <= element.hmin) or (rx >= element.hmax))) {
-                    lost_plane = Plane::x;
-                    status = Status::particle_lost;
-                }
-                if (((ry <= element.vmin) or (ry >= element.vmax))) {
-                    if (status != Status::particle_lost) {
-                        lost_plane = Plane::y;
-                        status = Status::particle_lost;
-                    } else {
-                        lost_plane = Plane::xy;
-                    }
-                }
-            } else if (get_norm_amp_in_vchamber(element, rx, ry) > 1) {
-                // lost in rhombus, elliptic and all finite p-norm shapes
-                lost_plane = Plane::xy;
-                status = Status::particle_lost;
-            }
-        }
+        status = track_elementpass(accelerator, element, orig_pos);
+        lost_plane = check_particle_loss(accelerator, element, orig_pos);
+        if (lost_plane != Plane::no_plane) status = Status::particle_lost;
 
         if (status != Status::success) {
             // fill rest of vector with nans
             for(int ii=i+1; ii<=nr_elements; ++ii) {
-                if (indcs[ii]) pos.emplace_back(
-                    nan(""),nan(""),nan(""),nan(""),nan(""),nan(""));
+                if (indcs[ii]) pos.emplace_back(nan(""));
             }
             return status;
         }
@@ -226,6 +186,316 @@ Status::type track_linepass (
     if (indcs[nr_elements]) pos.push_back(orig_pos);
 
     return (status == Status::success) ? status: Status::particle_lost;
+}
+
+// linepass
+// --------
+// tracks particles along a beam transport line
+//
+// inputs:
+//     accelerator: Element vector representing the beam transport line.
+//     orig_pos: Pos vector representing initial positions of particles.
+//     trajectory: whether to return coordinates at all elements.
+//     element_offset: equivalent to shifting the lattice so that
+//         '*element_offset' is the index for the first element.
+//
+// outputs:
+//     element_offset: in case of problems with passmethods, such as particle
+//         loss '*element_offset' is the index of the corresponding element.
+//     pos: Pos vector of particles coordinates at the start of every element,
+//         if trajectory == true, and at the end of the last element.
+//     lost_plane: which plane the particle was lost.
+//     lost_pos: return coordinates of lost particle.
+//
+// RETURN:
+//      status do tracking (see 'auxiliary.h')
+//
+template <typename T>
+Status::type track_linepass (
+    const Accelerator& accelerator,
+    Pos<T>& orig_pos,
+    const bool trajectory,
+    unsigned int& element_offset,
+    std::vector<Pos<T> >& pos,
+    Plane::type& lost_plane
+) {
+    std::vector<unsigned int> indices;
+    unsigned int nr_elements = accelerator.lattice.size();
+    if (trajectory){
+        indices.reserve(nr_elements + 1);
+        for (unsigned int i=0; i<=nr_elements; ++i) indices.push_back(i);
+    }else{
+        indices.push_back(nr_elements);
+    }
+
+    return track_linepass (
+        accelerator,
+        orig_pos,
+        indices,
+        element_offset,
+        pos,
+        lost_plane
+    );
+}
+
+
+// linepass
+// --------
+// tracks particles along a beam transport line
+//
+// inputs:
+//     accelerator: Element vector representing the beam transport line.
+//     orig_pos: Pos vector representing initial positions of particles.
+//     indices: vector of integers defining at which elements to return.
+//     element_offset: equivalent to shifting the lattice so that
+//         '*element_offset' is the index for the first element.
+//
+// outputs:
+//     element_offset: in case of problems with passmethods, such as particle
+//         loss '*element_offset' is the index of the corresponding element.
+//     pos: Pos vector of particles coordinates at the start of every element
+//         selected by indices and at the end of the last element.
+//     lost_plane: which plane each particle was lost.
+//     lost_flag: whether or not each particle was lost.
+//     lost_element: which element each particle was lost.
+//
+// RETURN:
+//      status do tracking (see 'auxiliary.h')
+//
+template <typename T>
+Status::type track_linepass (
+    const Accelerator& accelerator,
+    std::vector<Pos<T>> &orig_pos,
+    const std::vector<unsigned int >& indices,
+    const unsigned int element_offset,
+    std::vector<Pos<T>> &pos,
+    std::vector<unsigned int >& lost_plane,
+    std::vector<bool>& lost_flag,
+    std::vector<int>& lost_element
+) {
+
+    int nr_elements = accelerator.lattice.size();
+    Status::type status  = Status::success;
+    Status::type status2  = Status::success;
+    std::vector<Pos<T> > final_pos;
+    Plane::type lp;
+
+    pos.reserve(indices.size() * orig_pos.size());
+    lost_flag.reserve(orig_pos.size());
+    lost_plane.reserve(orig_pos.size());
+    lost_element.reserve(orig_pos.size());
+
+    for(unsigned int i=0; i<orig_pos.size(); ++i) {
+        unsigned int le = element_offset;
+
+        status2 = track_linepass(
+            accelerator, orig_pos[i], indices, le, final_pos, lp
+        );
+
+        if (status2 != Status::success){
+            status = status2;
+            lost_element.push_back(le);
+            lost_flag.push_back(true);
+        } else {
+            lost_element.push_back(-1);
+            lost_flag.push_back(false);
+        }
+        lost_plane.push_back(lp);
+        for (auto&& p: final_pos) pos.push_back(p);
+        final_pos.clear();
+    }
+    return status;
+}
+
+
+// linepass
+// --------
+// tracks particles along a beam transport line
+//
+// inputs:
+//     accelerator: Element vector representing the beam transport line.
+//     orig_pos: Pos vector representing initial positions of particles.
+//     indices: vector of integers defining at which elements to return.
+//     element_offset: equivalent to shifting the lattice so that
+//         '*element_offset' is the index for the first element.
+//
+// outputs:
+//     element_offset: in case of problems with passmethods, such as particle
+//         loss '*element_offset' is the index of the corresponding element.
+//     pos: Pos vector of particles coordinates at the start of every element,
+//         if trajectory == true, and at the end of the last element.
+//     lost_plane: which plane each particle was lost.
+//     lost_flag: whether or not each particle was lost.
+//     lost_element: which element each particle was lost.
+//
+// RETURN:
+//      status do tracking (see 'auxiliary.h')
+//
+
+// ringpass
+// --------
+// tracks particles around a ring
+//
+// inputs:
+//     accelerator: Element vector representing the beam transport line.
+//     orig_pos: Pos vector representing initial positions of particles.
+//     nr_turns: number of turns for tracking
+//     turn_by_turn: whether to return coordinates at all elements.
+//     element_offset: equivalent to shifting the lattice so that
+//         '*element_offset' is the index for the first element
+//
+// outputs:
+//     element_offset: in case of problems with passmethods, such as particle
+//         loss '*element_offset' is the index of the corresponding element.
+//     pos: Pos vector of particles coordinates of the turn_by_turn data
+//         (at end of the ring at each turn)
+//     lost_plane: which plane each particle was lost.
+//     lost_turn: which turn each particle was lost.
+//
+// RETURN:
+//     status do tracking (see 'auxiliary.h')
+template <typename T>
+Status::type track_ringpass (
+    const Accelerator& accelerator,
+    Pos<T>& orig_pos,
+    const unsigned int nr_turns,
+    const bool turn_by_turn,
+    unsigned int& element_offset,
+    std::vector<Pos<T> >& pos,
+    Plane::type& lost_plane,
+    unsigned int& lost_turn
+) {
+
+    Status::type status  = Status::success;
+    std::vector<Pos<T> > final_pos;
+
+    if (turn_by_turn) pos.reserve(nr_turns+1);
+
+    for(lost_turn=0; lost_turn<nr_turns; ++lost_turn) {
+
+        // stores turn_by_turn at beggining of each turn
+        if (turn_by_turn) pos.push_back(orig_pos);
+
+        if ((status = track_linepass(
+            accelerator,
+            orig_pos,
+            false,
+            element_offset,
+            final_pos,
+            lost_plane
+        )) != Status::success) {
+
+            // fill last of vector with nans
+            pos.emplace_back(nan(""));
+            if (turn_by_turn) for(int i=lost_turn+1; i<nr_turns; ++i) {
+                pos.emplace_back(nan(""));
+            }
+            return status;
+        }
+        final_pos.clear();
+    }
+    pos.push_back(orig_pos);
+
+    return status;
+}
+
+
+template <typename T>
+Status::type track_ringpass (
+    const Accelerator& accelerator,
+    std::vector<Pos<T> > &orig_pos,
+    const unsigned int nr_turns,
+    bool turn_by_turn,
+    unsigned int element_offset,
+    std::vector<Pos<T> > &pos,
+    std::vector<unsigned int>& lost_plane,
+    std::vector<int>& lost_turn,
+    std::vector<bool>& lost_flag,
+    std::vector<int>& lost_element
+) {
+
+    Status::type status  = Status::success;
+    Status::type status2  = Status::success;
+    std::vector<Pos<T> > final_pos;
+    unsigned int lt;
+    Plane::type lp;
+
+    if (turn_by_turn) pos.reserve((nr_turns + 1) * orig_pos.size());
+    else pos.reserve(orig_pos.size());
+    lost_turn.reserve(orig_pos.size());
+    lost_plane.reserve(orig_pos.size());
+    lost_element.reserve(orig_pos.size());
+    lost_flag.reserve(orig_pos.size());
+
+    for(unsigned int i=0; i<orig_pos.size(); ++i) {
+        unsigned int le = element_offset;
+
+        status2 = track_ringpass(
+            accelerator,
+            orig_pos[i],
+            nr_turns,
+            turn_by_turn,
+            le,
+            final_pos,
+            lp,
+            lt
+        );
+
+        if (status2 != Status::success) status = status2;
+
+        if (status2 != Status::success){
+            status = status2;
+            lost_turn.push_back(lt);
+            lost_element.push_back(le);
+            lost_flag.push_back(true);
+        } else {
+            lost_turn.push_back(-1);
+            lost_element.push_back(-1);
+            lost_flag.push_back(false);
+        }
+        lost_plane.push_back(lp);
+        for (auto&& p: final_pos) pos.push_back(p);
+        final_pos.clear();
+    }
+    return status;
+}
+
+
+// ------------------- auxiliary methods ----------------
+template <typename T>
+Plane::type check_particle_loss(
+    const Accelerator& accelerator,
+    const Element& ele,
+    const Pos<T>& orig_pos
+){
+
+    Plane::type lost_plane = Plane::no_plane;
+    const T& rx = orig_pos.rx;
+    const T& ry = orig_pos.ry;
+
+    if (not isfinite(rx)) lost_plane = Plane::x;
+    if (not isfinite(ry)) {
+        if (lost_plane == Plane::no_plane) return Plane::y;
+        else return Plane::xy;
+    }
+    if (lost_plane != Plane::no_plane) return lost_plane;
+
+    if (not accelerator.vchamber_on) return Plane::no_plane;
+
+    // invalid p-norm shape (negative p). Safely signals lost particle
+    if (ele.vchamber < 0) return Plane::xy;
+    // rectangular vacuum chamber
+    if (ele.vchamber == VChamberShape::rectangle) {
+        if (((rx <= ele.hmin) or (rx >= ele.hmax))) lost_plane = Plane::x;
+        if (((ry <= ele.vmin) or (ry >= ele.vmax))) {
+            if (lost_plane == Plane::no_plane) return Plane::y;
+            else return Plane::xy;
+        }
+        if (lost_plane != Plane::no_plane) return lost_plane;
+    }
+    // lost in rhombus, elliptic and all finite p-norm shapes
+    else if (get_norm_amp_in_vchamber(ele, rx, ry) > 1) return Plane::xy;
+    return lost_plane;
 }
 
 
@@ -246,167 +516,6 @@ T get_norm_amp_in_vchamber(const Element& elem, const T& rx, const T& ry) {
         amplitude = pow(xn, elem.vchamber) + pow(yn, elem.vchamber);
     }
     return amplitude;
-}
-
-
-template <typename T>
-Status::type track_linepass (
-        const Accelerator& accelerator,
-        Pos<T>& orig_pos,              // initial electron coordinates
-        std::vector<Pos<T> >& pos,     // vector with tracked electron coordinates at start of every element and at the end of last one.
-        unsigned int& element_offset,  // index of starting element for tracking
-        Plane::type& lost_plane,       // return plane in which particle was lost, if the case.
-        bool trajectory) {             // whether function should return coordinates at all elements
-
-    std::vector<unsigned int> indices;
-    unsigned int nr_elements = accelerator.lattice.size();
-
-    if (trajectory){
-        indices.reserve(nr_elements + 1);
-        for (unsigned int i=0; i<=nr_elements; ++i) indices.push_back(i);
-    }else{
-        indices.push_back(nr_elements);
-    }
-
-    return track_linepass (
-        accelerator, orig_pos, pos, element_offset, lost_plane, indices);
-}
-
-
-template <typename T>
-Status::type track_linepass (
-        const Accelerator& accelerator,
-        std::vector<Pos<T> > &orig_pos,
-        std::vector<Pos<T> > &pos,
-        unsigned int element_offset,
-        std::vector<unsigned int >& lost_plane,
-        std::vector<unsigned int >& lost_element,
-        std::vector<unsigned int >& indices) {
-
-    int nr_elements = accelerator.lattice.size();
-    Status::type status  = Status::success;
-    Status::type status2  = Status::success;
-    std::vector<Pos<T> > final_pos;
-    Plane::type lp;
-
-    pos.reserve(indices.size() * orig_pos.size());
-    lost_plane.reserve(orig_pos.size());
-    lost_element.reserve(orig_pos.size());
-
-    for(unsigned int i=0; i<orig_pos.size(); ++i) {
-        unsigned int le = element_offset;
-
-        status2 = track_linepass (
-            accelerator, orig_pos[i], final_pos, le, lp, indices);
-
-        if (status2 != Status::success) status = status2;
-
-        lost_plane.push_back(lp);
-        lost_element.push_back(le);
-        for (auto&& p: final_pos) pos.push_back(p);
-        final_pos.clear();
-    }
-    return status;
-}
-
-
-// ringpass
-// --------
-// tracks particles around a ring
-//
-// inputs:
-//        ring:             Element vector representing the ring
-//        orig_pos:        Pos vector representing initial positions of particles
-//        element_offset:    equivalent to shifting the lattice so that '*element_offset' is the index for the first element
-//        nr_turns:        number of turns for tracking
-//
-// outputs:
-//        pos:            Pos vector of particles' coordinates of the turn_by_turn data (at end of the ring at each turn)
-//        turn_idx:        in case of problems with passmethods, '*turn_idx' is the index of the corresponding turn
-//        element_offset:    in case of problems with passmethods, '*element_offset' is the index of the corresponding element
-//        RETURN:            status do tracking (see 'auxiliary.h')
-
-
-template <typename T>
-Status::type track_ringpass (
-        const Accelerator& accelerator,
-        Pos<T> &orig_pos,
-        std::vector<Pos<T> >& pos,
-        const unsigned int nr_turns,
-        unsigned int& lost_turn,
-        unsigned int& element_offset,
-        Plane::type& lost_plane,
-        bool trajectory) {
-
-    Status::type status  = Status::success;
-    std::vector<Pos<T> > final_pos;
-
-    if (trajectory) pos.reserve(nr_turns+1);
-
-    for(lost_turn=0; lost_turn<nr_turns; ++lost_turn) {
-
-        // stores trajectory at beggining of each turn
-        if (trajectory) pos.push_back(orig_pos);
-
-        if ((status = track_linepass (accelerator, orig_pos, final_pos, element_offset, lost_plane, false)) != Status::success) {
-
-            // fill last of vector with nans
-            pos.emplace_back(
-                nan(""),nan(""),nan(""),nan(""),nan(""),nan(""));
-            if (trajectory) for(int i=lost_turn+1; i<nr_turns; ++i) {
-                    pos.emplace_back(
-                        nan(""),nan(""),nan(""),nan(""),nan(""),nan(""));
-                }
-            return status;
-        }
-        final_pos.clear();
-    }
-    pos.push_back(orig_pos);
-
-    return status;
-}
-
-
-template <typename T>
-Status::type track_ringpass (
-        const Accelerator& accelerator,
-        std::vector<Pos<T> > &orig_pos,
-        std::vector<Pos<T> > &pos,
-        const unsigned int nr_turns,
-        std::vector<unsigned int > &lost_turn,
-        unsigned int element_offset,
-        std::vector<unsigned int >& lost_plane,
-        std::vector<unsigned int >& lost_element,
-        bool trajectory) {
-
-    Status::type status  = Status::success;
-    Status::type status2  = Status::success;
-    std::vector<Pos<T> > final_pos;
-    unsigned int lt;
-    Plane::type lp;
-
-    if (trajectory) pos.reserve((nr_turns + 1) * orig_pos.size());
-    else pos.reserve(orig_pos.size());
-    lost_turn.reserve(orig_pos.size());
-    lost_plane.reserve(orig_pos.size());
-    lost_element.reserve(orig_pos.size());
-
-    for(unsigned int i=0; i<orig_pos.size(); ++i) {
-        unsigned int le = element_offset;
-
-        status2 = track_ringpass(
-            accelerator, orig_pos[i], final_pos, nr_turns,
-            lt, le, lp, trajectory);
-
-        if (status2 != Status::success) status = status2;
-
-        lost_turn.push_back(lt);
-        lost_plane.push_back(lp);
-        lost_element.push_back(le);
-        for (auto&& p: final_pos) pos.push_back(p);
-        final_pos.clear();
-    }
-    return status;
 }
 
 #endif

--- a/python_package/interface.cpp
+++ b/python_package/interface.cpp
@@ -19,9 +19,10 @@
 
 
 Status::type track_elementpass_wrapper (
-         const Element& el,
-         double *pos, int n1, int n2,
-         const Accelerator& accelerator) {
+    const Accelerator& accelerator,
+    const Element& el,
+    double *pos, int n1, int n2
+) {
 
     std::vector<Pos<double> > post;
 
@@ -32,8 +33,7 @@ Status::type track_elementpass_wrapper (
             pos[2*n2 + i], pos[3*n2 + i],
             pos[4*n2 + i], pos[5*n2 + i]);
     }
-    Status::type status = track_elementpass(
-        el, post, accelerator);
+    Status::type status = track_elementpass(accelerator, el, post);
 
     for (unsigned int i=0; i<post.size(); ++i){
         pos[0*n2 + i] = post[i].rx; pos[1*n2 + i] = post[i].px;
@@ -44,10 +44,11 @@ Status::type track_elementpass_wrapper (
 }
 
 Status::type track_linepass_wrapper(
-        const Accelerator &accelerator,
-        double *orig_pos, int ni1, int ni2,
-        double *pos, int n1, int n2,
-        LinePassArgs& args) {
+    const Accelerator &accelerator,
+    double *orig_pos, int ni1, int ni2,
+    double *pos, int n1, int n2,
+    LinePassArgs& args
+) {
 
     std::vector<Pos<double> > post;
     std::vector<Pos<double> > orig_post;
@@ -57,28 +58,46 @@ Status::type track_linepass_wrapper(
         orig_post.emplace_back(
             orig_pos[0*ni2 + i], orig_pos[1*ni2 + i],
             orig_pos[2*ni2 + i], orig_pos[3*ni2 + i],
-            orig_pos[4*ni2 + i], orig_pos[5*ni2 + i]);
+            orig_pos[4*ni2 + i], orig_pos[5*ni2 + i]
+        );
     }
-    Status::type status = track_linepass(accelerator,
-                          orig_post,
-                          post,
-                          args.element_offset,
-                          args.lost_plane,
-                          args.lost_element,
-                          args.indices);
+    Status::type status = track_linepass(
+        accelerator,
+        orig_post,
+        args.indices,
+        args.element_offset,
+        post,
+        args.lost_plane,
+        args.lost_flag,
+        args.lost_element
+    );
     for (unsigned int i=0; i<post.size(); ++i){
         pos[0*n2 + i] = post[i].rx; pos[1*n2 + i] = post[i].px;
         pos[2*n2 + i] = post[i].ry; pos[3*n2 + i] = post[i].py;
         pos[4*n2 + i] = post[i].de; pos[5*n2 + i] = post[i].dl;
+    }
+    // lost positions
+    for (unsigned int i=0; i<orig_post.size(); ++i){
+        if (args.lost_flag[i]) {
+            orig_pos[0*ni2 + i] = orig_post[i].rx;
+            orig_pos[1*ni2 + i] = orig_post[i].px;
+            orig_pos[2*ni2 + i] = orig_post[i].ry;
+            orig_pos[3*ni2 + i] = orig_post[i].py;
+            orig_pos[4*ni2 + i] = orig_post[i].de;
+            orig_pos[5*ni2 + i] = orig_post[i].dl;
+        } else {
+            for (unsigned int j=0; j<6; ++j) orig_pos[j*ni2 + i] = nan("");
+        }
     }
     return status;
 }
 
 Status::type track_ringpass_wrapper (
-        const Accelerator& accelerator,
-        double *orig_pos, int ni1, int ni2,
-        double *pos, int n1, int n2,
-        RingPassArgs& args) {
+    const Accelerator& accelerator,
+    double *orig_pos, int ni1, int ni2,
+    double *pos, int n1, int n2,
+    RingPassArgs& args
+) {
 
     std::vector<Pos<double> > post;
     std::vector<Pos<double> > orig_post;
@@ -90,19 +109,35 @@ Status::type track_ringpass_wrapper (
             orig_pos[2*ni2 + i], orig_pos[3*ni2 + i],
             orig_pos[4*ni2 + i], orig_pos[5*ni2 + i]);
     }
-    Status::type status = track_ringpass(accelerator,
-                          orig_post,
-                          post,
-                          args.nr_turns,
-                          args.lost_turn,
-                          args.element_offset,
-                          args.lost_plane,
-                          args.lost_element,
-                          args.trajectory);
+    Status::type status = track_ringpass(
+        accelerator,
+        orig_post,
+        args.nr_turns,
+        args.turn_by_turn,
+        args.element_offset,
+        post,
+        args.lost_plane,
+        args.lost_turn,
+        args.lost_flag,
+        args.lost_element
+    );
     for (unsigned int i=0; i<post.size(); ++i){
         pos[0*n2 + i] = post[i].rx; pos[1*n2 + i] = post[i].px;
         pos[2*n2 + i] = post[i].ry; pos[3*n2 + i] = post[i].py;
         pos[4*n2 + i] = post[i].de; pos[5*n2 + i] = post[i].dl;
+    }
+    // lost positions
+    for (unsigned int i=0; i<orig_post.size(); ++i){
+        if (args.lost_flag[i]) {
+            orig_pos[0*ni2 + i] = orig_post[i].rx;
+            orig_pos[1*ni2 + i] = orig_post[i].px;
+            orig_pos[2*ni2 + i] = orig_post[i].ry;
+            orig_pos[3*ni2 + i] = orig_post[i].py;
+            orig_pos[4*ni2 + i] = orig_post[i].de;
+            orig_pos[5*ni2 + i] = orig_post[i].dl;
+        } else {
+            for (unsigned int j=0; j<6; ++j) orig_pos[j*ni2 + i] = nan("");
+        }
     }
     return status;
 }

--- a/python_package/interface.h
+++ b/python_package/interface.h
@@ -29,18 +29,20 @@
 
 struct LinePassArgs {
     unsigned int element_offset;
-    std::vector< unsigned int > indices;
-    std::vector< unsigned int > lost_plane;
-    std::vector< unsigned int > lost_element;
+    std::vector<unsigned int> indices;
+    std::vector<unsigned int> lost_plane;
+    std::vector<int> lost_element;
+    std::vector<bool> lost_flag;
 };
 
 struct RingPassArgs : public LinePassArgs {
     unsigned int nr_turns;
-    std::vector< unsigned int > lost_turn;
+    unsigned int turn_by_turn;
     unsigned int element_offset;
-    std::vector< unsigned int > lost_plane;
-    std::vector< unsigned int > lost_element;
-    unsigned int trajectory;
+    std::vector<unsigned int> lost_plane;
+    std::vector<int> lost_turn;
+    std::vector<int> lost_element;
+    std::vector<bool> lost_flag;
 };
 
 struct String {
@@ -50,28 +52,32 @@ public:
 };
 
 Status::type track_elementpass_wrapper (
-        const Element& el,
-        double *pos, int n1, int n2,
-        const Accelerator& accelerator);
+    const Accelerator& accelerator,
+    const Element& el,
+    double *pos, int n1, int n2
+);
 
 Status::type track_linepass_wrapper (
-        const Accelerator& accelerator,
-        double *orig_pos, int ni1, int ni2,
-        double *pos, int n1, int n2,
-        LinePassArgs& args);
+    const Accelerator& accelerator,
+    double *orig_pos, int ni1, int ni2,
+    double *pos, int n1, int n2,
+    LinePassArgs& args
+);
 
 Status::type track_ringpass_wrapper (
-        const Accelerator& accelerator,
-        double *orig_pos, int ni1, int ni2,
-        double *pos, int n1, int n2,
-        RingPassArgs& args);
+    const Accelerator& accelerator,
+    double *orig_pos, int ni1, int ni2,
+    double *pos, int n1, int n2,
+    RingPassArgs& args
+);
 
 Status::type calc_twiss_wrapper (
-        Accelerator& accelerator,
-        const Pos<double>& fixed_point,
-        Matrix& m66,
-        double *twiss, int n1, int n2,
-        Twiss twiss0);
+    Accelerator& accelerator,
+    const Pos<double>& fixed_point,
+    Matrix& m66,
+    double *twiss, int n1, int n2,
+    Twiss twiss0
+);
 
 Element marker_wrapper(const std::string& fam_name_);
 Element bpm_wrapper(const std::string& fam_name_);

--- a/python_package/trackcpp.i
+++ b/python_package/trackcpp.i
@@ -42,6 +42,8 @@ namespace std {
     %template(CppStringVector) vector<string>;
     %template(CppDoubleVector) vector<double>;
     %template(CppUnsigIntVector) vector<unsigned int>;
+    %template(CppIntVector) vector<int>;
+    %template(CppBoolVector) vector<bool>;
     %template(CppElementVector) vector<Element>;
     %template(CppDoublePosVector) vector< Pos<double> >;
     %template(CppDoubleMatrix) vector< vector<double> >;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -364,7 +364,7 @@ int cmd_dynap_acceptance(const std::vector<std::string>& args) {
     return EXIT_FAILURE;
   }
   std::cout << get_timestamp() << " input file with flat lattice read." << std::endl;
-  
+
   // builds accelerator
   accelerator.energy = ring_energy;
   accelerator.harmonic_number = harmonic_number;
@@ -1084,7 +1084,7 @@ int cmd_track_linepass(const std::vector<std::string>& args) {
   std::vector<Pos<double>> pos_list;
   Plane::type lost_plane;
   unsigned int offset_element = start_element;
-  track_linepass(accelerator, pos, pos_list, offset_element, lost_plane, true);
+  track_linepass(accelerator, pos, true, offset_element, pos_list, lost_plane);
 
   std::cout << get_timestamp() << " saving track_linepass data to file" << std::endl;
   status = print_tracking_linepass(accelerator, pos_list, start_element, "track_linepass_out.txt");

--- a/src/diffusion_matrix.cpp
+++ b/src/diffusion_matrix.cpp
@@ -256,7 +256,7 @@ Status::type track_diffusionmatrix (const Accelerator& accelerator,
       bdiff.sandwichme_with_matrix(tm[i]);
     bmat.push_back(bdiff);
     // track through element
-    track_elementpass (ele, fp, accelerator);
+    track_elementpass(accelerator, ele, fp);
   }
   return status;
 }

--- a/src/dynap.cpp
+++ b/src/dynap.cpp
@@ -820,7 +820,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false,
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status == Status::success) {
 //       e_stable    = e_unstable;
 //       e_unstable *= 2.0;
@@ -838,7 +847,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false,
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status == Status::success) {
 //       e_stable = e;
 //     } else {
@@ -882,7 +900,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status == Status::success) {
 //       px_stable    = px_unstable;
 //       px_unstable *= 2.0;
@@ -900,7 +927,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status == Status::success) {
 //       px_stable = px;
 //     } else {
@@ -944,7 +980,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status == Status::success) {
 //       py_stable    = py_unstable;
 //       py_unstable *= 2.0;
@@ -962,7 +1007,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status == Status::success) {
 //       py_stable = py;
 //     } else {
@@ -1003,7 +1057,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status != Status::success) {
 //       //e_stable    = e_unstable;
 //       last_unstable = point.p.de;
@@ -1031,7 +1094,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status != Status::success) {
 //       //e_stable    = e_unstable;
 //       last_unstable = point.p.px;
@@ -1059,7 +1131,16 @@ static Status::type calc_closed_orbit(const Accelerator& accelerator, std::vecto
 //     std::vector<Pos<double> > new_pos;
 //     Pos<double> p = point.p + cod[element_idx];  // p initial condition for tracking
 //     if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//     Status::type status = track_ringpass (accelerator, p, new_pos, nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//     Status::type status = track_ringpass (
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//     );
 //     if (status != Status::success) {
 //       //e_stable    = e_unstable;
 //       last_unstable = point.p.py;
@@ -1078,14 +1159,16 @@ static void thread_dynap_naff(ThreadSharedData* thread_data, int thread_id, long
 
   std::vector<Pos<double>> new_pos;
   Status::type lstatus = Status::success;
-  lstatus = track_ringpass (*thread_accelerator,
-                            p,
-                            new_pos,
-                            thread_nr_turns/2,
-                            grid[task_id].lost_turn,
-                            grid[task_id].lost_element,
-                            grid[task_id].lost_plane,
-                            true);
+  lstatus = track_ringpass (
+    *thread_accelerator,
+    p,
+    thread_nr_turns/2,
+    true,
+    grid[task_id].lost_element,
+    new_pos,
+    grid[task_id].lost_plane,
+    grid[task_id].lost_turn
+  );
   //pthread_mutex_lock(thread_data->mutex);
   if (lstatus == Status::success) naff_traj(new_pos, grid[task_id].nux1, grid[task_id].nuy1);
   //pthread_mutex_unlock(thread_data->mutex);
@@ -1097,15 +1180,16 @@ static void thread_dynap_naff(ThreadSharedData* thread_data, int thread_id, long
     //pthread_mutex_unlock(thread_data->mutex);
 
     std::vector<Pos<double>> new_pos;
-    lstatus = track_ringpass (*thread_accelerator,
-                              p,
-                              new_pos,
-                              thread_nr_turns/2,
-                              grid[task_id].lost_turn,
-                              grid[task_id].lost_element,
-                              grid[task_id].lost_plane,
-                              true);
-
+    lstatus = track_ringpass (
+      *thread_accelerator,
+      p,
+      thread_nr_turns/2,
+      true,
+      grid[task_id].lost_element,
+      new_pos,
+      grid[task_id].lost_plane,
+      grid[task_id].lost_turn
+    );
     //p = new_pos.back();
     //pthread_mutex_lock(thread_data->mutex);
     //printf("nan2 thread:%02i|task:%06lu/%06lu  rx:%+.4e|ry:%+.4e\n", thread_id, (1+task_id), thread_data->nr_tasks, p.rx, p.ry);
@@ -1145,14 +1229,16 @@ static void thread_dynap(ThreadSharedData* thread_data, int thread_id, long task
 
   std::vector<Pos<double>> new_pos;
   Status::type lstatus = Status::success;
-  lstatus = track_ringpass (*thread_accelerator,
-                            p,
-                            new_pos,
-                            thread_nr_turns,
-                            grid[task_id].lost_turn,
-                            grid[task_id].lost_element,
-                            grid[task_id].lost_plane,
-                            true);
+  lstatus = track_ringpass(
+    *thread_accelerator,
+    p,
+    thread_nr_turns,
+    true,
+    grid[task_id].lost_element,
+    new_pos,
+    grid[task_id].lost_plane,
+    grid[task_id].lost_turn
+  );
   if (thread_type.compare("xy") == 0) {
     pthread_mutex_lock(thread_data->mutex);
     printf("thread:%02i|task:%06lu/%06lu  rx:%+.4e|ry:%+.4e  turn:%05i|element:%05i  status:%s\n", thread_id, (1+task_id), thread_data->nr_tasks, grid[task_id].p.rx, grid[task_id].p.ry, grid[task_id].lost_turn, grid[task_id].lost_element, string_error_messages[lstatus].c_str());
@@ -1226,7 +1312,16 @@ static void thread_dynap(ThreadSharedData* thread_data, int thread_id, long task
 //       std::vector<Pos<double> > new_pos;
 //       Pos<double> p = point.p + (*thread_cod)[start_element];  // p initial condition for tracking
 //       if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//       Status::type status = track_ringpass (*thread_accelerator, p, new_pos, thread_nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//       Status::type status = track_ringpass(
+//         accelerator,
+//         p,
+//         nr_turns,
+//         false
+//         point.lost_element,
+//         new_pos,
+//         point.lost_plane,
+//         point.lost_turn
+//       );
 //       if (status != Status::success) { e -= e_delta; point.p.de = e; break; }
 //       e += e_delta;
 //     }
@@ -1294,7 +1389,16 @@ static void thread_dynap_acceptance(ThreadSharedData* thread_data, int thread_id
       std::vector<Pos<double> > new_pos;
       Pos<double> p = point.p + (*thread_cod)[start_element];  // p initial condition for tracking
       if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-      Status::type status = track_ringpass (*thread_accelerator, p, new_pos, thread_nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+      Status::type status = track_ringpass(
+        *thread_accelerator,
+        p,
+        thread_nr_turns,
+        false,
+        point.lost_element,
+        new_pos,
+        point.lost_plane,
+        point.lost_turn
+      );
       if (status != Status::success) {
         pa -= p_delta;
         if (calc_type == ma)  { point.p.de = pa; break; };
@@ -1356,7 +1460,16 @@ static void thread_dynap_acceptance(ThreadSharedData* thread_data, int thread_id
 //       std::vector<Pos<double> > new_pos;
 //       Pos<double> p = point.p + (*thread_cod)[start_element];  // p initial condition for tracking
 //       if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//       Status::type status = track_ringpass (*thread_accelerator, p, new_pos, thread_nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//       Status::type status = track_ringpass(
+//           *thread_accelerator,
+//           p,
+//           thread_nr_turns,
+//           false,
+//           point.lost_element,
+//           new_pos,
+//           point.lost_plane,
+//           point.lost_turn
+//       );
 //       if (status != Status::success) { px -= px_delta; point.p.px = px; break; }
 //       px += px_delta;
 //     }
@@ -1466,7 +1579,16 @@ static void thread_dynap_acceptance(ThreadSharedData* thread_data, int thread_id
 //       std::vector<Pos<double> > new_pos;
 //       Pos<double> p = point.p + (*thread_cod)[start_element];  // p initial condition for tracking
 //       if (fabs(p.ry) < tiny_y_amp) p.ry = sgn(p.ry) * tiny_y_amp;
-//       Status::type status = track_ringpass (*thread_accelerator, p, new_pos, thread_nr_turns, point.lost_turn, point.lost_element, point.lost_plane, false);
+//       Status::type status = track_ringpass(
+//           *thread_accelerator,
+//           p,
+//           thread_nr_turns,
+//           false,
+//           point.lost_element,
+//           new_pos,
+//           point.lost_plane,
+//           point.lost_turn
+//       );
 //       if (status != Status::success) { py -= py_delta; point.p.py = py; break; }
 //       py += py_delta;
 //     }

--- a/src/optics.cpp
+++ b/src/optics.cpp
@@ -81,7 +81,9 @@ Status::type calc_twiss(Accelerator& accelerator,
   std::vector<Pos<double>> closed_orbit;
   Plane::type lost_plane;
   unsigned int element_offset = 0;
-  Status::type status = track_linepass(accelerator, fp, closed_orbit, element_offset, lost_plane, true);
+  Status::type status = track_linepass(
+    accelerator, fp, true, element_offset, closed_orbit, lost_plane
+  );
   if (status != Status::success) return status;
 
 
@@ -148,7 +150,9 @@ Status::type calc_twiss(Accelerator& accelerator,
     fpp.px += twiss0.etax[1] * dpp;
     fpp.ry += twiss0.etay[0] * dpp;
     fpp.py += twiss0.etay[1] * dpp;
-    Status::type status = track_linepass(accelerator, fpp, codp, element_offset, lost_plane, true);
+    Status::type status = track_linepass(
+      accelerator, fpp, true, element_offset, codp, lost_plane
+    );
     if (status != Status::success) return status;
   }
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -89,7 +89,7 @@ int test_ringpass(const Accelerator& accelerator) {
 
   std::vector<Pos<double> > new_pos;
   unsigned int element_offset = 0;
-  int lost_turn = 0;
+  unsigned int lost_turn = 0;
   Plane::type lost_plane;
 
   clock_t begin, end;

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -36,7 +36,9 @@ int test_linepass(const Accelerator& accelerator) {
   std::vector<Pos<> > new_pos;
   unsigned int element_offset = 0;
   Plane::type lost_plane;
-  Status::type status = track_linepass(accelerator, pos, new_pos, element_offset, lost_plane, true);
+  Status::type status = track_linepass(
+    accelerator, pos, true, element_offset, new_pos, lost_plane
+  );
   std::cout << "status: " << string_error_messages[status] << std::endl;
 
 
@@ -65,7 +67,9 @@ int test_linepass_tpsa(const Accelerator& accelerator, const std::vector<Element
   std::vector<Pos<Tpsa<6,order> > > new_tpsa;
   unsigned int element_offset = 0;
   Plane::type lost_plane;
-  track_linepass(accelerator, tpsa, new_tpsa, element_offset, lost_plane, false);
+  track_linepass(
+    accelerator, tpsa, false, element_offset, new_tpsa, lost_plane
+  );
   for(unsigned int i=0; i<new_tpsa.size(); ++i) {
     //const Pos<Tpsa<6,1> >& c = new_particles[i];
     //std::cout << c.rx << std::endl;
@@ -84,13 +88,23 @@ int test_ringpass(const Accelerator& accelerator) {
   pos.ry = 0.00010;
 
   std::vector<Pos<double> > new_pos;
-  unsigned int element_offset = 0, lost_turn = 0;
+  unsigned int element_offset = 0;
+  int lost_turn = 0;
   Plane::type lost_plane;
 
   clock_t begin, end;
   double time_spent;
   begin = clock();
-  Status::type status = track_ringpass(accelerator, pos, new_pos, 5000, lost_turn, element_offset, lost_plane, true);
+  Status::type status = track_ringpass(
+    accelerator,
+    pos,
+    5000,
+    true,
+    element_offset,
+    new_pos,
+    lost_plane,
+    lost_turn
+  );
   end = clock();
   time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
 
@@ -339,7 +353,7 @@ int test_simple_drift() {
   accelerator.lattice.push_back(ds);
 
   Pos<double> pos(0.001,0.002,0.003,0.004,0.005,0.006);
-  track_elementpass (ds, pos, accelerator);
+  track_elementpass(accelerator, ds, pos);
 
   fprintf(stdout, "test_simple_drift\n");
   fprintf(stdout, "rx: %+.16f\n", pos.rx);
@@ -367,7 +381,7 @@ int test_simple_quadrupole() {
   accelerator.lattice.push_back(ds);
 
   Pos<double> pos(0.001,0.002,0.003,0.004,0.005,0.006);
-  track_elementpass (ds, pos, accelerator);
+  track_elementpass(accelerator, ds, pos);
 
   fprintf(stdout, "test_simple_quadrupole\n");
   fprintf(stdout, "rx: %+.16f\n", pos.rx);
@@ -398,12 +412,14 @@ int test_linepass2() {
   orig_pos.rx = 0.0001;
   orig_pos.px = 0.0001;
 
-  Status::type status = track_linepass (accelerator,
-      orig_pos,              // initial electron coordinates
-      pos,     // vector with electron coordinates from tracking at every element.
-      element_offset,  // index of starting element for tracking
-      lost_plane,       // return plane in which particle was lost, if the case.
-      trajectory);
+  Status::type status = track_linepass (
+      accelerator,
+      orig_pos,
+      trajectory,
+      element_offset,
+      pos,
+      lost_plane
+  );
 
       for(unsigned int i=0; i<10; ++i) {
         std::cout << std::endl;

--- a/src/tracking.cpp
+++ b/src/tracking.cpp
@@ -47,7 +47,7 @@ Status::type track_findm66 (Accelerator& accelerator,
   const std::vector<Element>& lattice = accelerator.lattice;
 
   Pos<double> fp = fixed_point;
-  
+
   const int radsts = accelerator.radiation_on;
   if (radsts == RadiationState::full){
     accelerator.radiation_on = RadiationState::damping;
@@ -85,7 +85,7 @@ Status::type track_findm66 (Accelerator& accelerator,
     tm.push_back(std::move(m));
     }
     // track through element
-    if ((status = track_elementpass (lattice[i], map, accelerator)) != Status::success) return status;
+    if ((status = track_elementpass(accelerator, lattice[i], map)) != Status::success) return status;
   }
 
   m66 = Matrix(6);
@@ -107,9 +107,9 @@ Status::type track_findm66 (Accelerator& accelerator,
 
   // constant term of the final map
   v0.rx = map.rx.c[0]; v0.px = map.px.c[0]; v0.ry = map.ry.c[0]; v0.py = map.py.c[0]; v0.de = map.de.c[0]; v0.dl = map.dl.c[0];
-  
+
   accelerator.radiation_on = radsts;
-  
+
   return status;
 
 }
@@ -173,13 +173,27 @@ Status::type track_findorbit6(
     Plane::type lost_plane;
     Status::type status = Status::success;
 
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[0], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[1], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[2], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[3], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[4], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[5], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[6], co2, element_offset, lost_plane, false));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[0], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[1], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[2], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[3], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[4], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[5], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[6], false, element_offset, co2, lost_plane
+    ));
 
     if (status != Status::success) {
       return Status::findorbit_one_turn_matrix_problem;
@@ -214,7 +228,9 @@ Status::type track_findorbit6(
   closed_orbit.clear();
   unsigned int element_offset = 0;
   Plane::type lost_plane;
-  track_linepass(accelerator, co[6], closed_orbit, element_offset, lost_plane, true);
+  track_linepass(
+    accelerator, co[6], true, element_offset, closed_orbit, lost_plane
+  );
   accelerator.radiation_on = radsts;
   return Status::success;
 
@@ -253,11 +269,21 @@ Status::type track_findorbit4(
     unsigned int element_offset = 0;
     Plane::type lost_plane;
     Status::type status = Status::success;
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[0], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[1], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[2], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[3], co2, element_offset, lost_plane, false));
-    status = (Status::type) ((int) status | (int) track_linepass(accelerator, co[6], co2, element_offset, lost_plane, false));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[0], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[1], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[2], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[3], false, element_offset, co2, lost_plane
+    ));
+    status = (Status::type) ((int) status | (int) track_linepass(
+      accelerator, co[6], false, element_offset, co2, lost_plane
+    ));
     if (status != Status::success) {
       return Status::findorbit_one_turn_matrix_problem;
     }
@@ -286,7 +312,9 @@ Status::type track_findorbit4(
   closed_orbit.clear();
   unsigned int element_offset = 0;
   Plane::type lost_plane;
-  track_linepass(accelerator, co[6], closed_orbit, element_offset, lost_plane, true);
+  track_linepass(
+    accelerator, co[6], true, element_offset, closed_orbit, lost_plane
+  );
   accelerator.radiation_on = radsts;
   return Status::success;
 

--- a/tests/test-kickmap.cpp
+++ b/tests/test-kickmap.cpp
@@ -52,7 +52,7 @@ int main() {
 
     fixed_point.rx = 0.001;
     std::cout << fixed_point << std::endl;
-    track_elementpass(accelerator.lattice[2], fixed_point, accelerator);
+    track_elementpass(accelerator, accelerator.lattice[2], fixed_point);
     std::cout << fixed_point << std::endl;
     return 0;
 
@@ -65,7 +65,9 @@ int main() {
     Plane::type lost_plane;
     unsigned int element_offset = 0;
 
-    status = track_linepass(accelerator, fp, closed_orbit, element_offset, lost_plane, true);
+    status = track_linepass(
+        accelerator, fp, true, element_offset, closed_orbit, lost_plane
+    );
     if (status != Status::success) return status;
 
     std::vector<Matrix> atm;
@@ -116,7 +118,9 @@ int main() {
         fpp.px += twiss0.etax[1] * dpp;
         fpp.ry += twiss0.etay[0] * dpp;
         fpp.py += twiss0.etay[1] * dpp;
-        Status::type status = track_linepass(accelerator, fpp, codp, element_offset, lost_plane, true);
+        Status::type status = track_linepass(
+            accelerator, fpp, true, element_offset, codp, lost_plane
+        );
         std::cout << "h2" << std::endl;
         if (status != Status::success) return status;
     }
@@ -132,7 +136,9 @@ int main() {
     // std::vector<Pos<double>> closed_orbit, traj;
     // Plane::type lost_plane;
     // unsigned int element_offset = 0;
-    // Status::type status1 = track_linepass(sirius, fp, traj, element_offset, lost_plane, true);
+    // Status::type status1 = track_linepass(
+    //     sirius, fp, true, element_offset, traj, lost_plane
+    // );
     // for(auto i=0; i <= closed_orbit)
     // std::cout << status1 << std::endl;
 


### PR DESCRIPTION
improvements related to interface of tracking functions:
 - improve docstring of `line_pass` and `ring_pass` functions;
 - fill `lost_element` and `lost_turn` with `-1` for particles that were not lost;
 - `lost_flag` is now a list of booleans for each particle;
 - change order of arguments in `element_pass`, `line_pass` and `ring_pass` so that they are sorted by constant inputs, changing inputs and pure outputs;
 - create separated method to check if particle was lost;
 - in python interface: fill numpy array of initial tracking coordinates with the coordinates at the point where particles were lost. For surviving particles, `nans` are used.