### PR TITLE
Bug FIX: Load/Save Translation and Rotation Flags

### DIFF
--- a/src/flat_file.cpp
+++ b/src/flat_file.cpp
@@ -28,8 +28,8 @@ static const int np = 17; // number precision
 static bool read_boolean_string(std::istringstream& ss);
 static int process_rad_property(std::istringstream& ss);
 static std::string get_boolean_string(bool value);
-static bool has_t_vector(const double* t);
-static bool has_r_matrix(const double* r);
+// static bool has_t_vector(const double* t);
+// static bool has_r_matrix(const double* r);
 static bool has_matrix66(const Matrix& r);
 static bool has_polynom(const std::vector<double>& p);
 static void write_6d_vector(std::ostream& fp, const std::string& label, const double* t);
@@ -129,9 +129,9 @@ void write_flat_file_trackcpp(std::ostream& fp, const Accelerator& accelerator) 
     if (e.angle_in != 0) { fp << std::setw(pw) << "angle_in" << e.angle_in << '\n'; }
     if (e.angle_out != 0) { fp << std::setw(pw) << "angle_out" << e.angle_out << '\n'; }
     if (e.rescale_kicks != 1.0) { fp << std::setw(pw) << "rescale_kicks" << e.rescale_kicks << '\n'; }
-    if (has_t_vector(e.t_in)) write_6d_vector(fp, "t_in", e.t_in);
-    if (has_t_vector(e.t_out)) write_6d_vector(fp, "t_out", e.t_out);
-    if (has_r_matrix(e.r_in)) {
+    if (e.has_t_in) write_6d_vector(fp, "t_in", e.t_in);
+    if (e.has_t_out) write_6d_vector(fp, "t_out", e.t_out);
+    if (e.has_r_in) {
       write_6d_vector(fp, "rx|r_in", &e.r_in[6*0]);
       write_6d_vector(fp, "px|r_in", &e.r_in[6*1]);
       write_6d_vector(fp, "ry|r_in", &e.r_in[6*2]);
@@ -139,7 +139,7 @@ void write_flat_file_trackcpp(std::ostream& fp, const Accelerator& accelerator) 
       write_6d_vector(fp, "de|r_in", &e.r_in[6*4]);
       write_6d_vector(fp, "dl|r_in", &e.r_in[6*5]);
     }
-    if (has_r_matrix(e.r_out)) {
+    if (e.has_r_out) {
       write_6d_vector(fp, "rx|r_out", &e.r_out[6*0]);
       write_6d_vector(fp, "px|r_out", &e.r_out[6*1]);
       write_6d_vector(fp, "ry|r_out", &e.r_out[6*2]);
@@ -309,6 +309,11 @@ Status::type read_flat_file_trackcpp(std::istream& fp, Accelerator& accelerator)
     return Status::flat_file_error;
   }
 
+  e.reflag_t_in();
+  e.reflag_t_out();
+  e.reflag_r_in();
+  e.reflag_r_out();
+
   if (e.fam_name.compare("") != 0) {
     accelerator.lattice.push_back(e);
   }
@@ -395,6 +400,12 @@ static Status::type read_flat_file_tracy(const std::string& filename, Accelerato
         e.r_out[2*6+0] =  S; e.r_out[2*6+2] =  C;
         e.r_out[1*6+1] =  C; e.r_out[1*6+3] = -S;
         e.r_out[3*6+1] =  S; e.r_out[3*6+3] =  C;
+
+        e.reflag_t_in();
+        e.reflag_t_out();
+        e.reflag_r_in();
+        e.reflag_r_out();
+
       }; break;
       case FlatFileType::kicktable:
       {
@@ -476,30 +487,30 @@ static std::string get_boolean_string(bool value) {
     return "false";
 }
 
-static bool has_t_vector(const double* t) {
-  for (int i=0; i<6; ++i)
-    if (t[i] != 0)
-      return true;
+// static bool has_t_vector(const double* t) {
+//   for (int i=0; i<6; ++i)
+//     if (t[i] != 0)
+//       return true;
 
-  return false;
-}
+//   return false;
+// }
 
-static bool has_r_matrix(const double* r) {
-  const double id[36] = {
-    1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-    0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
-    0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-    0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
-    0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
-    0.0, 0.0, 0.0, 0.0, 0.0, 1.0
-  };
+// static bool has_r_matrix(const double* r) {
+//   const double id[36] = {
+//     1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+//     0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+//     0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+//     0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+//     0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+//     0.0, 0.0, 0.0, 0.0, 0.0, 1.0
+//   };
 
-  for (int i=0; i<36; ++i)
-    if (r[i] != id[i])
-      return true;
+//   for (int i=0; i<36; ++i)
+//     if (r[i] != id[i])
+//       return true;
 
-  return false;
-}
+//   return false;
+// }
 
 static bool has_matrix66(const Matrix& m) {
   for (int i=0; i<6; ++i)

--- a/src/flat_file.cpp
+++ b/src/flat_file.cpp
@@ -28,8 +28,6 @@ static const int np = 17; // number precision
 static bool read_boolean_string(std::istringstream& ss);
 static int process_rad_property(std::istringstream& ss);
 static std::string get_boolean_string(bool value);
-// static bool has_t_vector(const double* t);
-// static bool has_r_matrix(const double* r);
 static bool has_matrix66(const Matrix& r);
 static bool has_polynom(const std::vector<double>& p);
 static void write_6d_vector(std::ostream& fp, const std::string& label, const double* t);
@@ -229,19 +227,27 @@ Status::type read_flat_file_trackcpp(std::istream& fp, Accelerator& accelerator)
     if (cmd.compare("angle_out")   == 0) { ss >> e.angle_out; continue; }
     if (cmd.compare("rescale_kicks")   == 0) { ss >> e.rescale_kicks; continue; }
     if (cmd.compare("t_in")      == 0) { for(auto i=0; i<6; ++i) ss >> e.t_in[i];  continue; }
+    e.reflag_t_in();
+
     if (cmd.compare("t_out")     == 0) { for(auto i=0; i<6; ++i) ss >> e.t_out[i]; continue; }
+    e.reflag_t_out();
+
     if (cmd.compare("rx|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[0*6+i]; continue; }
     if (cmd.compare("px|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[1*6+i]; continue; }
     if (cmd.compare("ry|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[2*6+i]; continue; }
     if (cmd.compare("py|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[3*6+i]; continue; }
     if (cmd.compare("de|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[4*6+i]; continue; }
     if (cmd.compare("dl|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[5*6+i]; continue; }
+    e.reflag_r_in();
+
     if (cmd.compare("rx|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[0*6+i]; continue; }
     if (cmd.compare("px|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[1*6+i]; continue; }
     if (cmd.compare("ry|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[2*6+i]; continue; }
     if (cmd.compare("py|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[3*6+i]; continue; }
     if (cmd.compare("de|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[4*6+i]; continue; }
     if (cmd.compare("dl|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[5*6+i]; continue; }
+    e.reflag_r_out();
+
     if (cmd.compare("rx|matrix66")  == 0) { for(auto i=0; i<6; ++i) ss >> e.matrix66[0][i]; continue; }
     if (cmd.compare("px|matrix66")  == 0) { for(auto i=0; i<6; ++i) ss >> e.matrix66[1][i]; continue; }
     if (cmd.compare("ry|matrix66")  == 0) { for(auto i=0; i<6; ++i) ss >> e.matrix66[2][i]; continue; }
@@ -308,11 +314,6 @@ Status::type read_flat_file_trackcpp(std::istream& fp, Accelerator& accelerator)
     if (line.size()<2) continue;
     return Status::flat_file_error;
   }
-
-  e.reflag_t_in();
-  e.reflag_t_out();
-  e.reflag_r_in();
-  e.reflag_r_out();
 
   if (e.fam_name.compare("") != 0) {
     accelerator.lattice.push_back(e);
@@ -486,31 +487,6 @@ static std::string get_boolean_string(bool value) {
   else
     return "false";
 }
-
-// static bool has_t_vector(const double* t) {
-//   for (int i=0; i<6; ++i)
-//     if (t[i] != 0)
-//       return true;
-
-//   return false;
-// }
-
-// static bool has_r_matrix(const double* r) {
-//   const double id[36] = {
-//     1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-//     0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
-//     0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-//     0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
-//     0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
-//     0.0, 0.0, 0.0, 0.0, 0.0, 1.0
-//   };
-
-//   for (int i=0; i<36; ++i)
-//     if (r[i] != id[i])
-//       return true;
-
-//   return false;
-// }
 
 static bool has_matrix66(const Matrix& m) {
   for (int i=0; i<6; ++i)

--- a/src/flat_file.cpp
+++ b/src/flat_file.cpp
@@ -226,28 +226,20 @@ Status::type read_flat_file_trackcpp(std::istream& fp, Accelerator& accelerator)
     if (cmd.compare("angle_in")    == 0) { ss >> e.angle_in;  continue; }
     if (cmd.compare("angle_out")   == 0) { ss >> e.angle_out; continue; }
     if (cmd.compare("rescale_kicks")   == 0) { ss >> e.rescale_kicks; continue; }
-    if (cmd.compare("t_in")      == 0) { for(auto i=0; i<6; ++i) ss >> e.t_in[i];  continue; }
-    e.reflag_t_in();
-
-    if (cmd.compare("t_out")     == 0) { for(auto i=0; i<6; ++i) ss >> e.t_out[i]; continue; }
-    e.reflag_t_out();
-
-    if (cmd.compare("rx|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[0*6+i]; continue; }
-    if (cmd.compare("px|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[1*6+i]; continue; }
-    if (cmd.compare("ry|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[2*6+i]; continue; }
-    if (cmd.compare("py|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[3*6+i]; continue; }
-    if (cmd.compare("de|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[4*6+i]; continue; }
-    if (cmd.compare("dl|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[5*6+i]; continue; }
-    e.reflag_r_in();
-
-    if (cmd.compare("rx|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[0*6+i]; continue; }
-    if (cmd.compare("px|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[1*6+i]; continue; }
-    if (cmd.compare("ry|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[2*6+i]; continue; }
-    if (cmd.compare("py|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[3*6+i]; continue; }
-    if (cmd.compare("de|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[4*6+i]; continue; }
-    if (cmd.compare("dl|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[5*6+i]; continue; }
-    e.reflag_r_out();
-
+    if (cmd.compare("t_in")      == 0) { for(auto i=0; i<6; ++i) ss >> e.t_in[i]; e.reflag_t_in(); continue; }
+    if (cmd.compare("t_out")     == 0) { for(auto i=0; i<6; ++i) ss >> e.t_out[i]; e.reflag_t_out(); continue; }
+    if (cmd.compare("rx|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[0*6+i]; e.reflag_r_in(); continue; }
+    if (cmd.compare("px|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[1*6+i]; e.reflag_r_in(); continue; }
+    if (cmd.compare("ry|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[2*6+i]; e.reflag_r_in(); continue; }
+    if (cmd.compare("py|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[3*6+i]; e.reflag_r_in(); continue; }
+    if (cmd.compare("de|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[4*6+i]; e.reflag_r_in(); continue; }
+    if (cmd.compare("dl|r_in")   == 0) { for(auto i=0; i<6; ++i) ss >> e.r_in[5*6+i]; e.reflag_r_in(); continue; }
+    if (cmd.compare("rx|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[0*6+i]; e.reflag_r_out(); continue; }
+    if (cmd.compare("px|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[1*6+i]; e.reflag_r_out(); continue; }
+    if (cmd.compare("ry|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[2*6+i]; e.reflag_r_out(); continue; }
+    if (cmd.compare("py|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[3*6+i]; e.reflag_r_out(); continue; }
+    if (cmd.compare("de|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[4*6+i]; e.reflag_r_out(); continue; }
+    if (cmd.compare("dl|r_out")  == 0) { for(auto i=0; i<6; ++i) ss >> e.r_out[5*6+i]; e.reflag_r_out(); continue; }
     if (cmd.compare("rx|matrix66")  == 0) { for(auto i=0; i<6; ++i) ss >> e.matrix66[0][i]; continue; }
     if (cmd.compare("px|matrix66")  == 0) { for(auto i=0; i<6; ++i) ss >> e.matrix66[1][i]; continue; }
     if (cmd.compare("ry|matrix66")  == 0) { for(auto i=0; i<6; ++i) ss >> e.matrix66[2][i]; continue; }


### PR DESCRIPTION
**Description:**
@Gabrielrezende-asc identified a bug in the _save/load_ functionality for `pyaccel.accelerator.Accelerator` objects when using pickle. 

This issue was introduced in Trackcpp's PR #71 and caused `Element` objects to be loaded without correctly setting the t_in, t_out, r_in, and r_out flags.

**Fix:**
This PR resolves the issue by using the `reflag_*` auxiliary functions inside `read_flat_file_trackcpp` for corretly loading Accelerator objects from pickles in Python.
The `reflag_*` functions are also used in `read_flat_file_tracy`.

**Extra:**
Changes also include the use of the `has_*` flags inside `write_flat_file_trackcpp`.