### PR TITLE
Update Ubuntu-version (GitHub Runner)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build using make and generate compile commands
         run: |
           make clean
-          CONDA_PREFIX=/dummy-prefix PIP=pip3 PYTHON=python3 bear make -j$(nproc)
+          CONDA_PREFIX=/dummy-prefix PIP=pip3 PYTHON=python3 bear --make -j$(nproc)
 
       # - name: Build using make and generate compile commands
       #   run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt update

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ In order to use clang-tidy, a compile_commands.json file must be present at the 
 In order to generate one and still use make as the build system:
 
 ```command
-# Compile using 'bear <build command>'
-bear make -j$(nproc)
+# Compile using 'bear -- <build command>'
+bear -- make -j$(nproc)
 ```


### PR DESCRIPTION
The latest Trackcpp commits and PRs have been failing to build on GitHub Actions. All failures show the same message: "_This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101_"

According to [this](https://github.com/actions/runner-images/issues/11101), the GitHub runner image `ubuntu-20.04` has been deprecated and was deactivated on April 15th, 2025. 

This PR updates the image to `ubuntu-latest` as suggested.

Alternatively, we can also choose a specific version among `ubuntu-22.04` or `ubuntu-24.04`.