### PR TITLE
Build on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ CFLAGS += $(WARNINGS_CFLAGS)
 LIBOBJECTS  = $(addprefix $(OBJDIR)/, $(LIBSOURCES_CPP:.cpp=.o))
 BINOBJECTS  = $(addprefix $(OBJDIR)/, $(BINSOURCES_CPP:.cpp=.o))
 LDFLAGS    = $(MACHINE)
+ifneq ($(CONDA_PREFIX),)
+    LDFLAGS += -Wl,-rpath,$(CONDA_PREFIX)/lib
+endif
 
 #### DERIVED CONDITIONALS AND VARIABLES ####
 ifeq ($(shell hostname), uv100)
@@ -134,7 +137,7 @@ endif
 all:  libtrackcpp trackcpp python_package
 
 #### GENERATES DEPENDENCY FILE ####
-$(shell $(CXX) -MM $(CFLAGS) $(addprefix $(SRCDIR)/, $(LIBSOURCES_CPP)) $(addprefix $(SRCDIR)/, $(BINSOURCES_CPP)) | sed 's/.*\.o/$(OBJDIR)\/&/' > .depend)
+$(shell $(CXX) -MM $(CFLAGS) $(INC) $(addprefix $(SRCDIR)/, $(LIBSOURCES_CPP)) $(addprefix $(SRCDIR)/, $(BINSOURCES_CPP)) | sed 's/.*\.o/$(OBJDIR)\/&/' > .depend)
 -include .depend
 
 libtrackcpp: $(OBJDIR)/libtrackcpp.a

--- a/include/trackcpp/auxiliary.h
+++ b/include/trackcpp/auxiliary.h
@@ -218,7 +218,7 @@ void set_random_distribution(unsigned value);
 double gen_random_number();
 
 
-#if __GNUC__ < 6
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 6
     bool isfinite(const double& v);
 #endif
 

--- a/python_package/Makefile
+++ b/python_package/Makefile
@@ -34,19 +34,31 @@ INC += -I../include $(PYTHON_INCLUDES) $(NUMPY_INCLUDE)
 INTERFACESRCS = $(INTERFACEOBJS:.o=.cpp)
 INTERFACEHDRS = $(INTERFACEOBJS:.o=.h)
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    SOFLAGS = -bundle -undefined dynamic_lookup
+    ifneq ($(CONDA_PREFIX),)
+        SOFLAGS += -Wl,-rpath,$(CONDA_PREFIX)/lib
+    endif
+    ARCHIVE_LINK = -Wl,-force_load,$(TRACKCPPLIB)
+else
+    SOFLAGS = -shared
+    ARCHIVE_LINK = -Wl,--whole-archive $(TRACKCPPLIB) -Wl,--no-whole-archive
+endif
+
 .NOTPARALLEL:
 
 all: trackcpp/_trackcpp.so
 
-$(shell $(CXX) -MM $(INTERFACESRCS) > .depend)
+$(shell $(CXX) -MM $(INC) $(INTERFACESRCS) > .depend)
 -include .depend
 
 trackcpp/_trackcpp.so: $(TRACKCPPLIB) $(OBJECTS)
-	$(CXX) -shared -Wl,--whole-archive $(TRACKCPPLIB) -Wl,--no-whole-archive $(OBJECTS) $(LIBS) -o trackcpp/_trackcpp.so
+	$(CXX) $(SOFLAGS) $(ARCHIVE_LINK) $(OBJECTS) $(LIBS) -o trackcpp/_trackcpp.so
 
 trackcpp_wrap.cxx: $(SOURCES_I) $(INTERFACESRCS) $(INTERFACEHDRS)
 	[ -f ./numpy.i ] && echo "numpy.i already here, good" || \
-	wget https://raw.githubusercontent.com/numpy/numpy/v$(NUMPY_VERSION)/tools/swig/numpy.i
+	(command -v wget >/dev/null 2>&1 && wget https://raw.githubusercontent.com/numpy/numpy/v$(NUMPY_VERSION)/tools/swig/numpy.i || curl -sL -o numpy.i https://raw.githubusercontent.com/numpy/numpy/v$(NUMPY_VERSION)/tools/swig/numpy.i)
 	$(SWIG) -c++ -python $(INC) trackcpp.i && cp -f trackcpp.py trackcpp
 
 install: uninstall all

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -40,7 +40,7 @@ Status::type print_closed_orbit(const Accelerator& accelerator, const std::vecto
     fprintf(fp, "# ebeam_energy[eV] : %f\n", accelerator.energy);
     fprintf(fp, "# harmonic_number  : %i\n", accelerator.harmonic_number);
     fprintf(fp, "# cavity_state     : %s\n", accelerator.cavity_on ? "on" : "off");
-    fprintf(fp, "# radiation_state  : %s\n", rad_dict[accelerator.radiation_on]);
+    fprintf(fp, "# radiation_state  : %s\n", rad_dict[accelerator.radiation_on].c_str());
     fprintf(fp, "# chamber_state    : %s\n", accelerator.vchamber_on ? "on" : "off");
     fprintf(fp, "\n");
     fprintf(fp, "%-5s %-15s %-24s %-24s %-24s %-24s %-24s %-24s %-24s\n", "# idx", "fam_name", "s[m]", "rx[m]", "px[rad]", "ry[m]", "py[rad]", "de", "dl[m]");
@@ -70,7 +70,7 @@ Status::type print_tracking_linepass(const Accelerator& accelerator, const std::
     fprintf(fp, "# ebeam_energy[eV]  : %f\n", accelerator.energy);
     fprintf(fp, "# harmonic_number   : %i\n", accelerator.harmonic_number);
     fprintf(fp, "# cavity_state      : %s\n", accelerator.cavity_on ? "on" : "off");
-    fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on]);
+    fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on].c_str());
     fprintf(fp, "# chamber_state     : %s\n", accelerator.vchamber_on ? "on" : "off");
     fprintf(fp, "\n");
 
@@ -104,7 +104,7 @@ Status::type print_tracking_ringpass(const Accelerator& accelerator, const std::
     fprintf(fp, "# ebeam_energy[eV]  : %f\n", accelerator.energy);
     fprintf(fp, "# harmonic_number   : %i\n", accelerator.harmonic_number);
     fprintf(fp, "# cavity_state      : %s\n", accelerator.cavity_on ? "on" : "off");
-    fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on]);
+    fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on].c_str());
     fprintf(fp, "# chamber_state     : %s\n", accelerator.vchamber_on ? "on" : "off");
     fprintf(fp, "\n");
 
@@ -135,7 +135,7 @@ Status::type print_dynapgrid(const Accelerator& accelerator, const std::vector<D
     fprintf(fp, "# ebeam_energy[eV]  : %f\n", accelerator.energy);
     fprintf(fp, "# harmonic_number   : %i\n", accelerator.harmonic_number);
     fprintf(fp, "# cavity_state      : %s\n", accelerator.cavity_on ? "on" : "off");
-    fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on]);
+    fprintf(fp, "# radiation_state   : %s\n", rad_dict[accelerator.radiation_on].c_str());
     fprintf(fp, "# chamber_state     : %s\n", accelerator.vchamber_on ? "on" : "off");
     fprintf(fp, "\n");
     if (print_tunes) {

--- a/src/trackcpp.cpp
+++ b/src/trackcpp.cpp
@@ -22,9 +22,11 @@
 
 bool verbose_on = true;
 
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 6
 bool isfinite(const double& v) {
 	return std::isfinite(v);
 }
+#endif
 
 std::string get_timestamp() {
 


### PR DESCRIPTION
With the help of AI chatbot, I modified trackcpp compilation/installation to build it in MacOS. 

Branch tested on:

- macOS: macOS 15.6.1 (Sequoia), arm64 (Apple Silicon), Apple clang 17.0.0. Conda env (gsl 2.8, swig 4.2.0, python 3.11.13, numpy 2.3.3, conda-forge). Full build (libtrackcpp.a, trackcpp binary, and the SWIG-generated _trackcpp.so Python extension).
- Linux: Rocky Linux 8.10, x86_64, GCC 8.5.0 (system compiler). Conda env (gsl 2.8, swig 4.4.1, python 3.11.15, numpy 2.4.6, conda-forge). Full build unaffected.

I would appreciate if you could test the branch on the LNLS computers as well. Thanks!

---
## [AI-generated summary] Fix macOS build (Apple Clang + conda toolchain)

trackcpp didn't build on macOS. This fixes it without changing behavior on Linux/GCC.

**`include/trackcpp/auxiliary.h`, `src/trackcpp.cpp`** — guard the custom `isfinite` shim to real GCC only.
`#if __GNUC__ < 6` was meant to declare a fallback `isfinite` for old GCC that lacks `std::isfinite`. Apple Clang also defines `__GNUC__` (for compatibility) at a value `< 6`, so this shim got compiled on macOS too, colliding with the standard library's own `isfinite`/`std::isfinite`. Changed to `defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 6` in both the declaration and the definition. No effect on real GCC builds.

**`Makefile`** — two independent fixes:
- `$(CXX) -MM ...` (auto-dependency generation) ran without `$(INC)`, so on macOS it can't resolve include paths (e.g. GSL from a non-default prefix) and fails/produces a broken `.depend`. Added `$(INC)` to the invocation.
- Added `LDFLAGS += -Wl,-rpath,$(CONDA_PREFIX)/lib` when `$(CONDA_PREFIX)` is set, so the binary can find libraries (e.g. GSL) installed in the active conda env at runtime — macOS doesn't fall back to the same default library search paths Linux does. No-op when not in a conda env.

**`python_package/Makefile`** — three fixes, all macOS-specific via a new `UNAME_S := $(shell uname -s)` branch (Linux path is untouched):
- Linking a Python extension `.so` on macOS needs `-bundle -undefined dynamic_lookup`, not `-shared` (ld64 doesn't support `-shared` the way GNU ld does for Python modules); added a `SOFLAGS` variable, Darwin vs. else.
- GNU ld's `-Wl,--whole-archive ... --no-whole-archive` (used to force-link all of `libtrackcpp.a` into the extension) isn't supported by macOS's linker; the equivalent is `-Wl,-force_load,$(TRACKCPPLIB)`. Added an `ARCHIVE_LINK` variable, same branch.
- The `-MM` dependency generation had the same missing-`$(INC)` problem as the top-level Makefile (can't find Python/numpy/GSL headers); fixed the same way.
- `numpy.i` was fetched with a hardcoded `wget` call; `wget` isn't installed by default on macOS. Falls back to `curl -sL` when `wget` isn't on `PATH`.

**`src/output.cpp`** — `fprintf(fp, "...%s...", rad_dict[accelerator.radiation_on])` passed a `std::string` directly through a varargs `%s`, which is undefined behavior (relies on the string's internal ABI layout rather than a `const char*`). It happened to work under libstdc++/GCC but breaks under libc++/Clang. Fixed all 4 call sites (`print_closed_orbit`, `print_tracking_linepass`, `print_tracking_ringpass`, `print_dynapgrid`) to use `.c_str()`. This is a real correctness fix, not macOS-only — worth taking regardless of platform.